### PR TITLE
separated annotation edit mode change handler for annootation and ann…

### DIFF
--- a/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.ts
+++ b/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.ts
@@ -62,4 +62,9 @@ export class AnnotationComponentForEditorComponent extends AnnotationComponent {
     this.babylon.hideMesh(this.annotation._id.toString(), true);
     this.showAnnotation = true;
   }
+
+  public handleEditModeChange() {
+    // empty handler to overwrite parent handler
+    // otherwise we would send multiple write requests per annotation
+  }
 }

--- a/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
+++ b/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
@@ -67,26 +67,7 @@ export class AnnotationComponent implements OnInit {
       this.isAnnotatingAllowed = allowed;
     });
 
-    this.annotationService.isEditModeAnnotation.subscribe(selectedEditAnno => {
-      if (!this.annotation) {
-        console.error('AnnotationComponent without annotation', this);
-        throw new Error('AnnotationComponent without annotation');
-      }
-      const isEditAnno = selectedEditAnno === this.annotation._id;
-      if (!isEditAnno && this.isEditMode) {
-        this.isEditMode = false;
-        this.annotationService.updateAnnotation(this.annotation);
-        console.log(this.isEditMode);
-      }
-      if (isEditAnno && !this.isEditMode) {
-        this.isEditMode = true;
-        console.log(this.isEditMode);
-        console.log(this.isAnnotatingAllowed);
-        console.log(this.isAnnotationOwner);
-
-        // this.annotationService.setSelectedAnnotation(this.annotation._id);
-      }
-    });
+    this.annotationService.isEditModeAnnotation.subscribe(this.handleEditModeChange.bind(this));
 
     setInterval(() => {
       if (!this.annotation) {
@@ -119,6 +100,27 @@ export class AnnotationComponent implements OnInit {
     this.annotationService.setEditModeAnnotation(
       this.isEditMode ? '' : this.annotation._id.toString(),
     );
+  }
+
+  public handleEditModeChange(selectedEditAnno : any) {
+    if (!this.annotation) {
+      console.error('AnnotationComponent without annotation', this);
+      throw new Error('AnnotationComponent without annotation');
+    }
+    const isEditAnno = selectedEditAnno === this.annotation._id;
+    if (!isEditAnno && this.isEditMode) {
+      this.isEditMode = false;
+      this.annotationService.updateAnnotation(this.annotation);
+      // console.log(this.isEditMode);
+    }
+    if (isEditAnno && !this.isEditMode) {
+      this.isEditMode = true;
+      // console.log(this.isEditMode);
+      // console.log(this.isAnnotatingAllowed);
+      // console.log(this.isAnnotationOwner);
+
+      // this.annotationService.setSelectedAnnotation(this.annotation._id);
+    }
   }
 
   public shareAnnotation() {


### PR DESCRIPTION
AnnotationComponentForEditorComponent extending AnnotationComponent leads to a duplicated subscription to annotationService.isEditModeAnnotation changes.

This in turn leads to duplicate write requests whenever an annotation is written. There are two ways to deal with this:

1. Overwrite AnnotationComponentForEditorComponent::ngOnInit, which would lead to duplicate code.
2. Implement the subscription handler in a function and overwrite that as an empty function.

This PR implements the second approach. Ideally write requests would be directly coupled to clicking the save button - not be a side effect of edit state changes, but this solution is a minimal change solving the duplicate writes.