### PR TITLE
avoid unnecessary writes to backend on annotation list sorts

### DIFF
--- a/src/app/services/annotation/annotation.service.ts
+++ b/src/app/services/annotation/annotation.service.ts
@@ -150,7 +150,15 @@ export class AnnotationService {
       await this.updateLocalDB(pouchAnnotations, serverAnnotations);
       const updated = await this.updateAnnotationList(pouchAnnotations, serverAnnotations);
       this.annotations.next(updated);
-      await this.sortAnnotations();
+
+      // above updateAnnotationList call already checks if values in pouchAnnotations changed
+      // and sends update requests to server.
+      // we still need to check if the order changed for which _id comparisons are sufficient
+      let unchanged = updated.length === serverAnnotations.length &&
+        updated.every((val, index) => val._id === serverAnnotations[index]._id);
+      if (!unchanged) {
+        await this.sortAnnotations();
+      }
     } else {
       if (this.processing.fallbackEntityLoaded) {
         this.annotations.next([annotationFallback]);


### PR DESCRIPTION
I noticed that if I have e.g. 6 annotations and press F5 all 5 annotations are rewritten to the database without any changes.
The reason is that on load PouchDB cached entries and fetched server entries are merged, checked for changes, merged and potentially written.
Then the resulting list is sorted which potentially alters annotation ranks and therefore triggers a write of all annotations.
This PR checks if the final list differs in length and order before issuing a sort in order to avoid unnecessary write load.