### PR TITLE
Fix: Vector3 referencePoint and referenceNormal being loaded incorrectly in AnnotationService due to changed saving of Vector3

### DIFF
--- a/src/app/services/annotation/annotation.service.ts
+++ b/src/app/services/annotation/annotation.service.ts
@@ -33,6 +33,15 @@ const isCompilationAnnotation = (annotation: IAnnotation) =>
 const sortByRanking = (a: IAnnotation, b: IAnnotation): number =>
   +a.ranking === +b.ranking ? 0 : +a.ranking < +b.ranking ? -1 : 1;
 
+interface IAmbiguousVector extends IVector3 {
+  _x?: number;
+  _y?: number;
+  _z?: number;
+}
+
+const getVector = ({ x, y, z, _x, _y, _z }: IAmbiguousVector) =>
+  _x && _y && _z ? new Vector3(_x, _y, _z) : new Vector3(x, y, z);
+
 @Injectable({
   providedIn: 'root',
 })
@@ -579,8 +588,8 @@ export class AnnotationService {
 
   public drawMarker(newAnnotation: IAnnotation) {
     const { referencePoint, referenceNormal } = newAnnotation.target.selector;
-    const positionVector = new Vector3(referencePoint.x, referencePoint.y, referencePoint.z);
-    const normalVector = new Vector3(referenceNormal.x, referenceNormal.y, referenceNormal.z);
+    const positionVector = getVector(referencePoint);
+    const normalVector = getVector(referenceNormal);
 
     const color = 'black';
     const scene = this.babylon.getScene();


### PR DESCRIPTION
In older annotations, the Vector3 referencePoint and referenceNormal were saved using the x,y and z properties of the Vector3.
At some point, either due to BabylonJS changes or due to a programming oversight, instead of the x, y and z properties instead the _x, _y and _z properties were saved.
This created an issue when attempting to load the saved Vector3's in the AnnotationService, always loading them as (0, 0, 0).

This pull request inserts a function to differentiate between the different versions of saved Vector3 and load it correctly.