### PR TITLE
Determine 3D model file extension in the load3DEntity method instead of passing it down from multiple functions

### DIFF
--- a/src/app/services/babylon/babylon.service.ts
+++ b/src/app/services/babylon/babylon.service.ts
@@ -306,7 +306,6 @@ export class BabylonService {
     clearScene: boolean,
     rootUrl: string,
     mediaType = 'model',
-    extension = 'babylon',
     isDefault?: boolean,
   ) {
     this.engine.displayLoadingUI();
@@ -357,7 +356,7 @@ export class BabylonService {
       case 'entity':
       case 'model':
       default:
-        return load3DEntity(rootUrl, extension, this.scene).then(result => {
+        return load3DEntity(rootUrl, this.scene).then(result => {
           if (result) {
             this.entityContainer = result;
             if (isDefault) {

--- a/src/app/services/babylon/strategies/loading-strategies.ts
+++ b/src/app/services/babylon/strategies/loading-strategies.ts
@@ -88,9 +88,10 @@ const patchMeshPBR = (mesh: AbstractMesh, scene: Scene) => {
   }
 };
 
-export const load3DEntity = (rootUrl: string, extension: string, scene: Scene) => {
+export const load3DEntity = (rootUrl: string, scene: Scene) => {
   const rootFolder = Tools.GetFolderPath(rootUrl);
   const filename = Tools.GetFilename(rootUrl);
+  const extension = filename.includes('.') ? `.${filename.split('.').slice(-1).pop()!}` : undefined;
 
   const engine = scene.getEngine();
 
@@ -100,7 +101,7 @@ export const load3DEntity = (rootUrl: string, extension: string, scene: Scene) =
     filename,
     scene,
     updateLoadingUI(engine),
-    extension.toLowerCase(),
+    extension,
   )
     .then(result => {
       console.log(result);

--- a/src/app/services/processing/processing.service.ts
+++ b/src/app/services/processing/processing.service.ts
@@ -263,7 +263,7 @@ export class ProcessingService {
   public loadFallbackEntity() {
     this.updateEntityQuality('low');
     this.entityMediaType = 'entity';
-    this.loadEntity(fallbackEntity as IEntity, '', '.gltf');
+    this.loadEntity(fallbackEntity as IEntity, '');
   }
 
   public fetchAndLoad(
@@ -398,7 +398,7 @@ export class ProcessingService {
       });
   }
 
-  public async loadEntity(newEntity: IEntity, overrideUrl?: string, extension = '.babylon') {
+  public async loadEntity(newEntity: IEntity, overrideUrl?: string) {
     const baseURL = overrideUrl ?? this.baseUrl;
     if (!this.loadingScreenHandler.isLoading && newEntity.processed && newEntity.mediaType) {
       if (!newEntity.dataSource.isExternal) {
@@ -413,14 +413,13 @@ export class ProcessingService {
         // cases: entity, image, audio, video, text
         const path: string = newEntity.externalFile ?? newEntity.processed[this.entityQuality];
         const url = path.includes('http') || path.includes('https') ? path : `${baseURL}${path}`;
-        extension = url.slice(url.lastIndexOf('.'));
 
         const mediaType = newEntity.mediaType;
         switch (newEntity.mediaType) {
           case 'model':
           case 'entity':
             await this.babylon
-              .loadEntity(true, url, mediaType, extension, newEntity._id === 'default')
+              .loadEntity(true, url, mediaType, newEntity._id === 'default')
               .then(() => {
                 this.updateActiveEntity(newEntity);
                 this.updateActiveEntityMeshes(
@@ -452,7 +451,7 @@ export class ProcessingService {
             break;
           case 'audio':
             await this.babylon
-              .loadEntity(true, 'assets/models/kompakkt.babylon', 'model', '.babylon', true)
+              .loadEntity(true, 'assets/models/kompakkt.babylon', 'model', true)
               .then(() => {
                 this.updateActiveEntityMeshes(
                   this.babylon.entityContainer.meshes as Mesh[],


### PR DESCRIPTION
The BabylonJS SceneLoader accepts a file extension as a parameter to determine which plugin should be used for loading a 3D model.
Previously, this extension was determined and passed down in multiple methods, but determining it in the method where it is actually used works just the same way.

This pull request removes the unnecessary passing of the extension parameter in BabylonService and ProcessingService, leaving it only in the loading-strategies.ts file.