### PR TITLE
Feature: allow the Viewer to be used fully standalone with additional query parameters

### DIFF
--- a/src/app/components/entity-feature-settings/entity-feature-settings.component.html
+++ b/src/app/components/entity-feature-settings/entity-feature-settings.component.html
@@ -167,17 +167,31 @@
         </div>
       </mat-step>
 
-      <mat-step>
-        <ng-template matStepLabel>Done</ng-template>
-        <img class="previewimage" [src]="processing.entitySettings.preview" />
-        You set all settings and I celebrate it with this preview.
-        <br />
-        Please save them if you are done. Afterwards you may add annotations.
-        <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button (click)="saveSettings()">Save</button>
-        </div>
-      </mat-step>
+      <ng-container *ngIf="!(isStandalone$ | async); else standaloneExport">
+        <mat-step>
+          <ng-template matStepLabel>Done</ng-template>
+          <img class="previewimage" [src]="processing.entitySettings.preview" />
+          You set all settings and I celebrate it with this preview.
+          <br />
+          Please save them if you are done. Afterwards you may add annotations.
+          <div>
+            <button mat-button matStepperPrevious>Back</button>
+            <button mat-button (click)="saveSettings()">Save</button>
+          </div>
+        </mat-step>
+      </ng-container>
+
+      <ng-template #standaloneExport>
+        <mat-step>
+          <ng-template matStepLabel>Export</ng-template>
+          <img class="previewimage" [src]="processing.entitySettings.preview" />
+          Your settings can now be exported and loaded in the standalone Kompakkt viewer.
+          <div>
+            <button mat-button matStepperPrevious>Back</button>
+            <button mat-button (click)="exportSettings()">Export</button>
+          </div>
+        </mat-step>
+      </ng-template>
     </mat-vertical-stepper>
   </div>
 </div>

--- a/src/app/components/entity-feature-settings/entity-feature-settings.component.ts
+++ b/src/app/components/entity-feature-settings/entity-feature-settings.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatStepper } from '@angular/material/stepper';
 import { map } from 'rxjs/operators';
+import { saveAs } from 'file-saver';
 
 import { environment } from '../../../environments/environment';
 import { BabylonService } from '../../services/babylon/babylon.service';
@@ -48,6 +49,10 @@ export class EntityFeatureSettingsComponent {
         return value;
       }),
     );
+  }
+
+  get isStandalone$() {
+    return this.processing.isStandalone$;
   }
 
   public setInitialPerspectivePreview() {
@@ -115,6 +120,16 @@ export class EntityFeatureSettingsComponent {
         }
       });
     }
+  }
+
+  public exportSettings() {
+    if (!this.processing.entitySettings) {
+      console.error(this);
+      throw new Error('Settings missing');
+    }
+    const settings = this.processing.entitySettings;
+    const blob = new Blob([JSON.stringify(settings)], { type: 'text/plain;charset=utf-8' });
+    saveAs(blob, 'settings.json');
   }
 
   public backToDefaultSettings() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "target": "es2015",
     "typeRoots": ["node_modules/@types", "src/@types"],
     "types": ["babylonjs", "babylonjs-gui"],
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017", "dom", "es2019", "dom.iterable"],
     "paths": {
       "core-js/es7/reflect": ["node_modules/core-js/proposals/reflect-metadata"],
       "~common/*": ["./src/common/*"]


### PR DESCRIPTION
Previously, the viewer was only really usable with some instance of the Kompakkt server, since it depended on multiple pieces of information saved on the server, f.e. user data, entity settings or annotations.

This pull request adds a new mode to the viewer, using the query parameter `standalone`, which in turn puts the viewer in a server independent state.

Aside from the `standalone` parameter, the viewer can also receive the following parameters:
- `endpoint`, **(required)** which should point to the base URL of any files hosted and loaded by the other parameters
- `resource`, **(required)** which should be the path to a 3D model or different file type usable by the viewer, excluding the base URL
- `settings` **(optional)**, which should be the path to a JSON file containing appropriate settings for the given `resource`
- `annotations` **(optional)**, which should be the path to a JSON file containing annotations matching the given `resource`

If settings and/or annotations are omitted, the viewer will be put into a state where settings/annotations can be set and exported, to later be used with the parameters.

No user data is associated with any activity in the standalone viewer mode.