### PR TITLE
Refactor service data flow

### DIFF
--- a/src/app/components/compilation-browser/compilation-browser.component.html
+++ b/src/app/components/compilation-browser/compilation-browser.component.html
@@ -1,6 +1,6 @@
 <div id="compilationBrowser">
-  <div *ngIf="compilation">
-    <div id="entity-overview" *ngIf="processing.entity$ | async; let entity">
+  <div *ngIf="compilation$ | async as compilation">
+    <div id="entity-overview" *ngIf="entity$ | async as entity">
       <mat-card class="entity-card">
         <mat-card-header>
           <mat-card-title> Selected Object: {{ entity.name }} </mat-card-title>
@@ -12,10 +12,12 @@
       </mat-card>
     </div>
 
-    <div class="category">Object{{ entityCount > 1 ? 's' : '' }} in {{ compilation.name }}:</div>
+    <ng-container *ngIf="entities$ | async as entities">
+      <div class="category">
+        Object{{ entities.length > 1 ? 's' : '' }} in {{ compilation.name }}:
+      </div>
 
-    <ng-container *ngFor="let entity of currentEntities">
-      <mat-card class="entity-card" *ngIf="isEntity(entity)">
+      <mat-card class="entity-card" *ngFor="let entity of entities">
         <mat-card-header>
           <mat-card-title>
             {{ entity.name }}
@@ -24,7 +26,7 @@
         <img
           *ngIf="entity.settings && entity.settings.preview"
           [src]="server_url + entity.settings.preview"
-          (click)="processing.fetchAndLoad(entity._id, undefined, true)"
+          (click)="processing.fetchAndLoad(entity._id, undefined)"
         />
       </mat-card>
     </ng-container>

--- a/src/app/components/compilation-browser/compilation-browser.component.ts
+++ b/src/app/components/compilation-browser/compilation-browser.component.ts
@@ -1,10 +1,8 @@
 import { Component } from '@angular/core';
-
-import { ProcessingService } from '../../services/processing/processing.service';
-
-import { isEntity, isCompilation, ICompilation } from 'src/common';
-
+import { filter, map } from 'rxjs';
+import { isCompilation, isEntity } from 'src/common';
 import { environment } from 'src/environments/environment';
+import { ProcessingService } from '../../services/processing/processing.service';
 
 @Component({
   selector: 'app-compilation-browser',
@@ -12,21 +10,23 @@ import { environment } from 'src/environments/environment';
   styleUrls: ['./compilation-browser.component.scss'],
 })
 export class CompilationBrowserComponent {
-  public compilation: ICompilation | undefined;
   public server_url = environment.server_url;
 
-  public isEntity = isEntity;
+  constructor(public processing: ProcessingService) {}
 
-  constructor(public processing: ProcessingService) {
-    this.processing.compilation$.subscribe(compilation => (this.compilation = compilation));
+  get compilation$() {
+    return this.processing.compilation$;
   }
 
-  get currentEntities() {
-    if (!isCompilation(this.compilation)) return [];
-    return Object.values(this.compilation.entities);
+  get entity$() {
+    return this.processing.entity$;
   }
 
-  get entityCount() {
-    return this.currentEntities.length;
+  get entities$() {
+    return this.compilation$.pipe(
+      filter(isCompilation),
+      map(({ entities }) => Object.values(entities)),
+      map(entities => entities.filter(isEntity)),
+    );
   }
 }

--- a/src/app/components/dialogs/dialog-get-user-data/dialog-get-user-data.component.ts
+++ b/src/app/components/dialogs/dialog-get-user-data/dialog-get-user-data.component.ts
@@ -31,11 +31,7 @@ export class DialogGetUserDataComponent {
       this.backend
         .deleteRequest(this.id, 'annotation', this.username, this.password)
         .then(() => {
-          this.userdata.loginData = {
-            username: this.username,
-            password: this.password,
-            isCached: true,
-          };
+          this.userdata.loginData$.next({ username: this.username, password: this.password });
           this.dialogRef.close(true);
           this.message.info('Deleted from Server');
         })

--- a/src/app/components/dialogs/dialog-invite-broadcasting/dialog-invite-broadcasting.component.html
+++ b/src/app/components/dialogs/dialog-invite-broadcasting/dialog-invite-broadcasting.component.html
@@ -1,11 +1,14 @@
-<ng-container *ngIf="compilation">
+<ng-container *ngIf="compilation$ | async as compilation">
   <mat-dialog-content>
     <mat-form-field>
       <h3>Invitation for Collaborators</h3>
       <textarea
         matInput
         placeholder="You can edit this Text"
-        [value]="text + (processing.defaultEntityLoaded ? defaultURL : baseURL + compilation._id)"
+        [value]="
+          text +
+          ((processing.defaultEntityLoaded$ | async) ? defaultURL : baseURL + compilation._id)
+        "
         #userinput
         cdkTextareaAutosize
         cdkAutosizeMinRows="4"

--- a/src/app/components/dialogs/dialog-invite-broadcasting/dialog-invite-broadcasting.component.ts
+++ b/src/app/components/dialogs/dialog-invite-broadcasting/dialog-invite-broadcasting.component.ts
@@ -1,8 +1,5 @@
 import { Component } from '@angular/core';
-
 import { ProcessingService } from '../../../services/processing/processing.service';
-
-import { ICompilation } from 'src/common';
 
 @Component({
   selector: 'app-dialog-invite-broadcasting',
@@ -18,10 +15,10 @@ export class DialogInviteBroadcastingComponent {
   public defaultURL = 'https://blacklodge.hki.uni-koeln.de/builds/Kompakkt/live/';
   public collectionId: string | undefined;
 
-  public compilation: ICompilation | undefined;
+  constructor(public processing: ProcessingService) {}
 
-  constructor(public processing: ProcessingService) {
-    this.processing.compilation$.subscribe(compilation => (this.compilation = compilation));
+  get compilation$() {
+    return this.processing.compilation$;
   }
 
   copyInputMessage(inputElement: HTMLTextAreaElement) {

--- a/src/app/components/entity-feature-annotations/annotation-media-browser/media-browser.component.html
+++ b/src/app/components/entity-feature-annotations/annotation-media-browser/media-browser.component.html
@@ -11,7 +11,7 @@
       <mat-icon aria-label="Add External Image">image</mat-icon>
     </button>
     <button
-      *ngIf="compilation"
+      *ngIf="compilation$ | async"
       mat-icon-button
       (click)="addCompilationEntity = !addCompilationEntity"
       matTooltip="Add Entity From Collection"
@@ -55,11 +55,13 @@
   <div *ngIf="addCompilationEntity" id="collection-entities">
     <h3>Or embed an entity of your collection:</h3>
 
-    <ng-container *ngFor="let entity of currentEntities; let i = index">
-      <mat-card (click)="addEntity(i)" class="compilation-entity" *ngIf="isEntity(entity)">
-        <img mat-card-image [src]="server_url + entity.settings.preview" [alt]="entity.name" />
-        <mat-card-footer>{{ entity.name }}</mat-card-footer>
-      </mat-card>
-    </ng-container>
+    <mat-card
+      *ngFor="let entity of entities$ | async; let i = index"
+      (click)="addEntity(i)"
+      class="compilation-entity"
+    >
+      <img mat-card-image [src]="server_url + entity.settings.preview" [alt]="entity.name" />
+      <mat-card-footer>{{ entity.name }}</mat-card-footer>
+    </mat-card>
   </div>
 </div>

--- a/src/app/components/entity-feature-annotations/annotation-media-browser/media-browser.component.ts
+++ b/src/app/components/entity-feature-annotations/annotation-media-browser/media-browser.component.ts
@@ -1,47 +1,44 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
-
-import { ProcessingService } from '../../../services/processing/processing.service';
-
-import { isCompilation, isEntity, ICompilation } from 'src/common';
-
+import { Component, EventEmitter, Output } from '@angular/core';
+import { filter, firstValueFrom, map } from 'rxjs';
+import { isCompilation, isEntity } from 'src/common';
 import { environment } from 'src/environments/environment';
+import { ProcessingService } from '../../../services/processing/processing.service';
 
 @Component({
   selector: 'app-media-browser',
   templateUrl: './media-browser.component.html',
   styleUrls: ['./media-browser.component.scss'],
 })
-export class MediaBrowserComponent implements OnInit {
+export class MediaBrowserComponent {
   @Output() addMedia = new EventEmitter();
 
   public url = '';
-  public compilation: ICompilation | undefined;
   public description = '';
 
   public addExternalImage = false;
   public addCompilationEntity = false;
 
-  public isEntity = isEntity;
   public server_url = environment.server_url;
 
   constructor(public processing: ProcessingService) {}
 
-  ngOnInit() {
-    this.processing.compilation$.subscribe(compilation => {
-      if (isCompilation(compilation)) this.compilation = compilation;
-    });
+  get compilation$() {
+    return this.processing.compilation$;
   }
 
-  get currentEntities() {
-    if (!isCompilation(this.compilation)) return [];
-    return Object.values(this.compilation.entities);
+  get entities$() {
+    return this.compilation$.pipe(
+      filter(isCompilation),
+      map(({ entities }) => Object.values(entities)),
+      map(entities => entities.filter(isEntity)),
+    );
   }
 
   private hideBrowser() {
     this.addExternalImage = this.addCompilationEntity = false;
   }
 
-  addImage(url: string, description: string) {
+  public addImage(url: string, description: string) {
     this.hideBrowser();
     this.addMedia.emit({
       mediaType: 'externalImage',
@@ -50,8 +47,9 @@ export class MediaBrowserComponent implements OnInit {
     });
   }
 
-  addEntity(index: number) {
+  public async addEntity(index: number) {
     this.hideBrowser();
-    this.addMedia.emit(this.currentEntities[index]);
+    const entities = await firstValueFrom(this.entities$);
+    this.addMedia.emit(entities[index]);
   }
 }

--- a/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
+++ b/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
@@ -53,7 +53,7 @@
 
       <mat-checkbox
         class="validation"
-        *ngIf="isEditMode && userOwnsCompilation"
+        *ngIf="isEditMode && (userdata.userOwnsCompilation$ | async)"
         [checked]="annotation.validated"
         (change)="annotation.validated = !annotation.validated"
         >Validated
@@ -78,29 +78,39 @@
         {{ this.showAnnotation ? 'Hide' : 'Show' }}
       </mat-slide-toggle>
 
-      <button
-        mat-icon-button
-        (click)="toggleEditViewMode()"
-        [matTooltip]="isEditMode ? 'Save Annotation' : 'Edit Annotation'"
-        *ngIf="isAnnotatingAllowed && isAnnotationOwner"
-        matTooltipPosition="above"
-        type="button"
-      >
-        <mat-icon [attr.aria-label]="isEditMode ? 'Save Annotation' : 'Edit Annotation'">{{
-          isEditMode ? 'save' : 'edit'
-        }}</mat-icon>
-      </button>
+      <ng-container *ngIf="(processing.hasAnnotationAllowance$ | async) && isAnnotationOwner">
+        <button
+          mat-icon-button
+          (click)="toggleEditViewMode()"
+          [matTooltip]="isEditMode ? 'Save Annotation' : 'Edit Annotation'"
+          matTooltipPosition="above"
+          type="button"
+        >
+          <mat-icon [attr.aria-label]="isEditMode ? 'Save Annotation' : 'Edit Annotation'">{{
+            isEditMode ? 'save' : 'edit'
+          }}</mat-icon>
+        </button>
 
-      <button
-        mat-icon-button
-        (click)="editFullscreen()"
-        matTooltip="Edit in Fullscreen Mode"
-        matTooltipPosition="above"
-        type="button"
-        *ngIf="isAnnotatingAllowed && isAnnotationOwner"
-      >
-        <mat-icon aria-label="Fullscreen">select_all</mat-icon>
-      </button>
+        <button
+          mat-icon-button
+          (click)="editFullscreen()"
+          matTooltip="Edit in Fullscreen Mode"
+          matTooltipPosition="above"
+          type="button"
+        >
+          <mat-icon aria-label="Fullscreen">select_all</mat-icon>
+        </button>
+
+        <button
+          mat-icon-button
+          (click)="deleteAnnotation()"
+          matTooltip="Delete"
+          matTooltipPosition="above"
+          type="button"
+        >
+          <mat-icon aria-label="Delete">delete</mat-icon>
+        </button>
+      </ng-container>
 
       <button
         mat-icon-button
@@ -111,17 +121,6 @@
         type="button"
       >
         <mat-icon aria-label="Copy to collection">file_copy</mat-icon>
-      </button>
-
-      <button
-        *ngIf="isAnnotatingAllowed && isAnnotationOwner"
-        mat-icon-button
-        (click)="deleteAnnotation()"
-        matTooltip="Delete"
-        matTooltipPosition="above"
-        type="button"
-      >
-        <mat-icon aria-label="Delete">delete</mat-icon>
       </button>
     </mat-card-actions>
   </form>

--- a/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
+++ b/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
@@ -53,7 +53,7 @@
 
       <mat-checkbox
         class="validation"
-        *ngIf="isEditMode && (userdata.userOwnsCompilation$ | async)"
+        *ngIf="isEditMode && (userOwnsCompilation$ | async)"
         [checked]="annotation.validated"
         (change)="annotation.validated = !annotation.validated"
         >Validated

--- a/src/app/components/entity-feature-annotations/annotation/annotation.component.html
+++ b/src/app/components/entity-feature-annotations/annotation/annotation.component.html
@@ -51,14 +51,13 @@
       </div>
     </mat-card-content>
 
-    <mat-card-actions>
+    <mat-card-actions *ngIf="(isAnnotatingAllowed$ | async) && isAnnotationOwner">
       <button
         mat-icon-button
         (click)="editFullscreen()"
         matTooltip="Edit in Fullscreen Mode"
         matTooltipPosition="above"
         type="button"
-        *ngIf="isAnnotatingAllowed && isAnnotationOwner"
       >
         <mat-icon aria-label="Fullscreen">select_all</mat-icon>
       </button>
@@ -67,7 +66,6 @@
         mat-icon-button
         (click)="toggleEditViewMode()"
         [matTooltip]="isEditMode ? 'Save Annotation' : 'Edit Annotation'"
-        *ngIf="isAnnotatingAllowed && isAnnotationOwner"
         matTooltipPosition="above"
         type="button"
       >
@@ -77,7 +75,6 @@
       </button>
 
       <button
-        *ngIf="isAnnotatingAllowed && isAnnotationOwner"
         mat-icon-button
         (click)="deleteAnnotation()"
         matTooltip="Delete"

--- a/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
+++ b/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
@@ -1,9 +1,9 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { IAnnotation } from 'src/common';
 import { Matrix, Vector3 } from '@babylonjs/core';
+import { map } from 'rxjs';
+import { IAnnotation } from 'src/common';
 import { environment } from 'src/environments/environment';
-
 import { AnnotationService } from '../../../services/annotation/annotation.service';
 import { BabylonService } from '../../../services/babylon/babylon.service';
 import { ProcessingService } from '../../../services/processing/processing.service';
@@ -35,6 +35,9 @@ export class AnnotationComponent implements OnInit {
   public visibility = false;
   public isAnnotatingAllowed$ = this.processing.hasAnnotationAllowance$;
   public isAnnotationOwner = false;
+  public userOwnsCompilation$ = this.processing.compilation$.pipe(
+    map(compilation => this.userdata.doesUserOwn(compilation)),
+  );
 
   constructor(
     public annotationService: AnnotationService,

--- a/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
+++ b/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
@@ -33,14 +33,14 @@ export class AnnotationComponent implements OnInit {
 
   // external
   public visibility = false;
-  public isAnnotatingAllowed = false;
+  public isAnnotatingAllowed$ = this.processing.hasAnnotationAllowance$;
   public isAnnotationOwner = false;
 
   constructor(
     public annotationService: AnnotationService,
     public babylon: BabylonService,
     public dialog: MatDialog,
-    private userdataService: UserdataService,
+    public userdata: UserdataService,
     public processing: ProcessingService,
   ) {}
 
@@ -51,10 +51,9 @@ export class AnnotationComponent implements OnInit {
     }
     this.showAnnotation = true;
     this.collapsed = false;
-    this.isAnnotatingAllowed = this.processing.annotationAllowance;
-    this.isAnnotationOwner = this.userdataService.isAnnotationOwner(this.annotation);
+    this.isAnnotationOwner = this.userdata.isAnnotationOwner(this.annotation);
 
-    this.annotationService.isSelectedAnnotation.subscribe(selectedAnno => {
+    this.annotationService.selectedAnnotation$.subscribe(selectedAnno => {
       if (!this.annotation) {
         console.error('AnnotationComponent without annotation', this);
         throw new Error('AnnotationComponent without annotation');
@@ -63,11 +62,7 @@ export class AnnotationComponent implements OnInit {
       this.selectedAnnotation = selectedAnno;
     });
 
-    this.processing.setAnnotationAllowance.subscribe((allowed: boolean) => {
-      this.isAnnotatingAllowed = allowed;
-    });
-
-    this.annotationService.isEditModeAnnotation.subscribe(this.handleEditModeChange.bind(this));
+    this.annotationService.editModeAnnotation$.subscribe(this.handleEditModeChange.bind(this));
 
     setInterval(() => {
       if (!this.annotation) {
@@ -82,10 +77,6 @@ export class AnnotationComponent implements OnInit {
     const preview = this.annotation?.body.content.relatedPerspective.preview;
     if (!preview) return undefined;
     return preview.startsWith('data:image') ? preview : environment.server_url + preview;
-  }
-
-  get userOwnsCompilation() {
-    return this.userdataService.userOwnsCompilation;
   }
 
   public closeAnnotation(): void {

--- a/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.html
+++ b/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.html
@@ -1,19 +1,19 @@
-<mat-card *ngIf="processing.upload">
+<mat-card *ngIf="processing.isInUpload$ | async">
   Please set and save the settings before you add annotations.
 </mat-card>
 
-<mat-card *ngIf="isDefault">
+<mat-card *ngIf="isDefault$ | async">
   All annotations you create are default annotations and visible for everyone who can access the
   entity.
 </mat-card>
 
-<mat-card *ngIf="isForbidden">
+<mat-card *ngIf="isForbidden$ | async">
   Default Annotations are not editable for foreign entities. Load entity from a collection to save
   your annotations to make them visible for others. If you are the owner of this entity do not load
   it from a collection to edit the default Annotations.
 </mat-card>
 
-<mat-card *ngIf="isAnnotatingAllowed">
+<mat-card *ngIf="isAnnotatingAllowed$ | async">
   To add annotations, simply double-click on the entity.
 </mat-card>
 
@@ -27,11 +27,7 @@
     class="annotation-box"
     *ngFor="let annotation of currentAnnotations$ | async"
     [annotation]="annotation"
-    [cdkDragDisabled]="
-      !(processing.compilationLoaded
-        ? userdata.userOwnsCompilation && isAnnotatingAllowed
-        : isAnnotatingAllowed)
-    "
+    [cdkDragDisabled]="isDraggingDisabled$ | async"
     cdkDrag
     cdkDragLockAxis="y"
   ></app-annotation-for-editor>

--- a/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.ts
+++ b/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.ts
@@ -1,9 +1,8 @@
 import { CdkDragDrop } from '@angular/cdk/drag-drop';
-import { Component, OnInit, QueryList, ViewChildren } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Component, QueryList, ViewChildren } from '@angular/core';
 import { saveAs } from 'file-saver';
-
+import { combineLatest, firstValueFrom } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { AnnotationService } from '../../../services/annotation/annotation.service';
 import { ProcessingService } from '../../../services/processing/processing.service';
 import { UserdataService } from '../../../services/userdata/userdata.service';
@@ -14,12 +13,12 @@ import { AnnotationComponent } from '../annotation/annotation.component';
   templateUrl: './annotations-editor.component.html',
   styleUrls: ['./annotations-editor.component.scss'],
 })
-export class AnnotationsEditorComponent implements OnInit {
+export class AnnotationsEditorComponent {
   @ViewChildren(AnnotationComponent)
   annotationsList: QueryList<AnnotationComponent> | undefined;
 
   // external
-  public isAnnotatingAllowed = false;
+  public isAnnotatingAllowed$ = this.processing.hasAnnotationAllowance$;
 
   public currentAnnotations$ = this.annotations.currentAnnotations$;
 
@@ -33,27 +32,38 @@ export class AnnotationsEditorComponent implements OnInit {
     return this.currentAnnotations$.pipe(map(arr => arr.length));
   }
 
-  get isDefault() {
-    if (!this.isAnnotatingAllowed) return false;
-    if (this.processing.compilationLoaded) return false;
-    return true;
-  }
-
-  get isForbidden() {
-    return (
-      !this.processing.upload &&
-      !this.isAnnotatingAllowed &&
-      !this.processing.compilationLoaded &&
-      !this.processing.defaultEntityLoaded
+  get isDefault$() {
+    return combineLatest([
+      this.processing.hasAnnotationAllowance$,
+      this.processing.compilationLoaded$,
+    ]).pipe(
+      map(
+        ([isAnnotatingAllowed, isCompilationLoaded]) => isAnnotatingAllowed && !isCompilationLoaded,
+      ),
     );
   }
 
-  ngOnInit() {
-    this.isAnnotatingAllowed = this.processing.annotationAllowance;
+  get isForbidden$() {
+    return combineLatest([
+      this.processing.isInUpload$,
+      this.processing.hasAnnotationAllowance$,
+      this.processing.compilationLoaded$,
+      this.processing.defaultEntityLoaded$,
+    ]).pipe(map(arr => arr.every(boolean => !boolean)));
+  }
 
-    this.processing.setAnnotationAllowance.subscribe((allowed: boolean) => {
-      this.isAnnotatingAllowed = allowed;
-    });
+  get isDraggingDisabled$() {
+    return combineLatest([
+      this.processing.hasAnnotationAllowance$,
+      this.processing.compilationLoaded$,
+      this.userdata.userOwnsCompilation$,
+    ]).pipe(
+      map(([isAnnotatingAllowed, isCompilationLoaded, userOwnsCompilation]) => {
+        if (!isAnnotatingAllowed) return true;
+        if (isCompilationLoaded) return userOwnsCompilation;
+        return false;
+      }),
+    );
   }
 
   drop(event: CdkDragDrop<string[]>) {

--- a/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.ts
+++ b/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.ts
@@ -56,11 +56,11 @@ export class AnnotationsEditorComponent {
     return combineLatest([
       this.processing.hasAnnotationAllowance$,
       this.processing.compilationLoaded$,
-      this.userdata.userOwnsCompilation$,
+      this.processing.compilation$,
     ]).pipe(
-      map(([isAnnotatingAllowed, isCompilationLoaded, userOwnsCompilation]) => {
+      map(([isAnnotatingAllowed, isCompilationLoaded, compilation]) => {
         if (!isAnnotatingAllowed) return true;
-        if (isCompilationLoaded) return userOwnsCompilation;
+        if (isCompilationLoaded) return this.userdata.doesUserOwn(compilation);
         return false;
       }),
     );

--- a/src/app/components/entity-feature-annotations/annotationwalkthrough/annotationwalkthrough.component.ts
+++ b/src/app/components/entity-feature-annotations/annotationwalkthrough/annotationwalkthrough.component.ts
@@ -22,7 +22,7 @@ export class AnnotationwalkthroughComponent implements OnInit {
       this.ranking = -1;
     });
 
-    this.annotationService.isSelectedAnnotation.subscribe(currentAnnotation => {
+    this.annotationService.selectedAnnotation$.subscribe(currentAnnotation => {
       const selectedAnnotation = this.annotations.find(
         (anno: IAnnotation) => anno._id === currentAnnotation,
       );

--- a/src/app/components/entity-feature-settings/entity-feature-settings-lights/entity-feature-settings-lights.component.ts
+++ b/src/app/components/entity-feature-settings/entity-feature-settings-lights/entity-feature-settings-lights.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 
 import { EntitySettingsService } from '../../../services/entitysettings/entitysettings.service';
 import { LightService } from '../../../services/light/light.service';
@@ -27,15 +28,12 @@ export class EntityFeatureSettingsLightsComponent {
   }
 
   // Lights
-  setLightIntensity(intensity: number | null, lightType: string) {
+  public async setLightIntensity(intensity: number | null, lightType: string) {
     if (!intensity) intensity = 0;
-    if (!this.processing.entitySettings) {
-      console.error(this);
-      throw new Error('Settings missing');
-    }
+    const { localSettings } = await firstValueFrom(this.processing.settings$);
     const indexOfLight = this.lights.getLightIndexByType(lightType);
     if (indexOfLight !== undefined) {
-      this.processing.entitySettings.lights[indexOfLight].intensity = intensity;
+      localSettings.lights[indexOfLight].intensity = intensity;
       this.entitySettings.loadLightIntensity(lightType);
     } else {
       console.error(this);
@@ -43,31 +41,24 @@ export class EntityFeatureSettingsLightsComponent {
     }
   }
 
-  getLightIntensity(lightType: string): number {
-    if (!this.processing.entitySettings) {
-      console.error(this);
-      throw new Error('Settings missing');
-    }
+  public getLightIntensity(lightType: string) {
     return this.lights.getLightByType(lightType)?.intensity ?? 0;
   }
 
-  setPointlightPosition(dimension: string, value: number | null) {
+  public async setPointlightPosition(dimension: string, value: number | null) {
     if (!value) value = 0;
-    if (!this.processing.entitySettings) {
-      console.error(this);
-      throw new Error('Settings missing');
-    }
+    const { localSettings } = await firstValueFrom(this.processing.settings$);
     const indexOfLight = this.lights.getLightIndexByType('pointLight');
     if (indexOfLight) {
       switch (dimension) {
         case 'x':
-          this.processing.entitySettings.lights[indexOfLight].position.x = value;
+          localSettings.lights[indexOfLight].position.x = value;
           break;
         case 'y':
-          this.processing.entitySettings.lights[indexOfLight].position.y = value;
+          localSettings.lights[indexOfLight].position.y = value;
           break;
         case 'z':
-          this.processing.entitySettings.lights[indexOfLight].position.z = value;
+          localSettings.lights[indexOfLight].position.z = value;
           break;
         default:
           // tslint:disable-next-line:prefer-template

--- a/src/app/components/entity-feature-settings/entity-feature-settings-mesh/entity-feature-settings-mesh.component.html
+++ b/src/app/components/entity-feature-settings/entity-feature-settings-mesh/entity-feature-settings-mesh.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="processing.entitySettings">
+<ng-container *ngIf="processing.settings$ | async as settings">
   <ng-template matStepLabel>Set Mesh Settings</ng-template>
   <h5>
     Information & Helpers
@@ -19,7 +19,7 @@
     <button class="fullwidth-button" mat-raised-button (click)="resetVisualUIMeshSettingsHelper()">
       Reset Helper
     </button>
-    <h5>Number of meshes: {{ meshes ? meshes.length : 0 }}</h5>
+    <h5 *ngIf="meshes$ | async as meshes">Number of meshes: {{ meshes.length }}</h5>
     <mat-checkbox [checked]="boundingBoxVisibility" (change)="toggleBoundingBoxEntityVisibility()">
       <h5>Bounding Box Entity</h5>
     </mat-checkbox>
@@ -165,12 +165,12 @@
       cm
     </h6>
 
-    <h6>Scale factor: {{ processing.entitySettings.scale }}</h6>
+    <h6>Scale factor: {{ settings.localSettings.scale }}</h6>
     <mat-slider
       min="0.0"
       max="5"
       step="0.05"
-      [value]="processing.entitySettings.scale"
+      [value]="settings.localSettings.scale"
       #matslider
       (input)="handleChangeDimension('scale', $event.value)"
     ></mat-slider>
@@ -208,7 +208,7 @@
         matInput
         min="0"
         max="360"
-        [(ngModel)]="processing.entitySettings.rotation.x"
+        [(ngModel)]="settings.localSettings.rotation.x"
         type="number"
         step="1"
         (input)="entitySettings.loadRotation()"
@@ -239,7 +239,7 @@
         matInput
         min="0"
         max="360"
-        [(ngModel)]="processing.entitySettings.rotation.y"
+        [(ngModel)]="settings.localSettings.rotation.y"
         type="number"
         step="1"
         (input)="entitySettings.loadRotation()"
@@ -270,7 +270,7 @@
         matInput
         min="0"
         max="360"
-        [(ngModel)]="processing.entitySettings.rotation.z"
+        [(ngModel)]="settings.localSettings.rotation.z"
         type="number"
         step="1"
         (input)="entitySettings.loadRotation()"

--- a/src/app/components/entity-feature-settings/entity-feature-settings.component.html
+++ b/src/app/components/entity-feature-settings/entity-feature-settings.component.html
@@ -1,197 +1,190 @@
-<div *ngIf="(settingsReady$ | async) && processing.entitySettings" id="editor-entitysettings">
-  <div *ngIf="processing.upload === false">
-    <mat-card>
-      <mat-card-content>
-        <button
-          id="resetDefaultSettings"
-          class="fullwidth-button"
-          mat-raised-button
-          (click)="backToDefaultSettings()"
-        >
-          Back to Default
-        </button>
-        <button
-          id="saveDefaultSettings"
-          class="fullwidth-button"
-          mat-raised-button
-          *ngIf="
-            !processing.defaultEntityLoaded &&
-            !processing.fallbackEntityLoaded &&
-            userdata.userOwnsEntity &&
-            !processing.compilationLoaded &&
-            processing.mode === 'edit'
-          "
-          (click)="saveSettings()"
-        >
-          Save as default
-        </button>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title> Background </mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <color-chrome (onChange)="setBackgroundColor($event.color.rgb)"></color-chrome>
-        <br />
-        <mat-slide-toggle
-          [(ngModel)]="processing.entitySettings.background.effect"
-          (change)="entitySettings.loadBackgroundEffect()"
-        >
-          Gradient-Brightness Effect
-        </mat-slide-toggle>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title> Lights </mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <app-entity-feature-settings-lights></app-entity-feature-settings-lights>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title> Preview & Initial Perspective </mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        Click on this image to set actual view as initial perspective.
-        <img
-          class="previewimage"
-          [src]="processing.entitySettings.preview"
-          (click)="setInitialPerspectivePreview()"
-        />
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-content>
-        <button class="fullwidth-button" mat-raised-button (click)="backToDefaultSettings()">
-          Back to Default
-        </button>
-        <button
-          class="fullwidth-button"
-          mat-raised-button
-          *ngIf="
-            !processing.defaultEntityLoaded &&
-            userdata.userOwnsEntity &&
-            !processing.compilationLoaded &&
-            processing.mode === 'edit'
-          "
-          (click)="saveSettings()"
-        >
-          Save as default
-        </button>
-      </mat-card-content>
-    </mat-card>
-  </div>
-
-  <div *ngIf="processing.upload">
-    <mat-vertical-stepper [linear]="true" #stepper>
-      <mat-step *ngIf="processing.meshSettings">
-        <app-entity-feature-settings-mesh></app-entity-feature-settings-mesh>
-        <div>
-          <button mat-button (click)="showNextAlertFirstStep()">Next</button>
-        </div>
-      </mat-step>
-
-      <mat-step>
-        <ng-template matStepLabel>Set Initial Settings</ng-template>
-        <h5>
-          Background
-          <button
-            mat-icon-button
-            (click)="backgroundToggle = !backgroundToggle"
-            matTooltip="Toggle"
-            matTooltipPosition="above"
-            type="button"
-          >
-            <mat-icon>
-              {{ backgroundToggle ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
-            </mat-icon>
-          </button>
-        </h5>
-        <div *ngIf="backgroundToggle">
-          <color-chrome (onChange)="setBackgroundColor($event.color.rgb)"></color-chrome>
-          <br />
-          <mat-slide-toggle
-            [(ngModel)]="processing.entitySettings.background.effect"
-            (change)="entitySettings.loadBackgroundEffect()"
-          >
-            Gradient-Brightness Effect
-          </mat-slide-toggle>
-        </div>
-        <h5>
-          Lights
-          <button
-            mat-icon-button
-            (click)="lightsToggle = !lightsToggle"
-            matTooltip="Toggle"
-            matTooltipPosition="above"
-            type="button"
-          >
-            <mat-icon>
-              {{ lightsToggle ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
-            </mat-icon>
-          </button>
-        </h5>
-        <div *ngIf="lightsToggle">
-          <app-entity-feature-settings-lights></app-entity-feature-settings-lights>
-        </div>
-        <div *ngIf="processing.entityMediaType !== 'audio'">
-          <h5>
-            Preview & Initial Perspective
+<ng-container *ngIf="settingsReady$ | async">
+  <ng-container *ngIf="processing.settings$ | async as settings">
+    <div *ngIf="" id="editor-entitysettings">
+      <div *ngIf="(processing.isInUpload$ | async) === false">
+        <mat-card>
+          <mat-card-content>
             <button
-              mat-icon-button
-              (click)="previewToggle = !previewToggle"
-              matTooltip="Toggle"
-              matTooltipPosition="above"
-              type="button"
+              id="resetDefaultSettings"
+              class="fullwidth-button"
+              mat-raised-button
+              (click)="backToDefaultSettings()"
             >
-              <mat-icon>
-                {{ previewToggle ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
-              </mat-icon>
+              Back to Default
             </button>
-          </h5>
-          <div *ngIf="previewToggle">
-            Please select a nice and fitting camera perspective before you go on to the next step.
-            By clicking on the next button the actual view will be set as initial perspective. And I
-            will automatically produce a preview - smile!
-          </div>
-        </div>
-        <div>
-          <button mat-button (click)="nextSecondStep()">Next</button>
-        </div>
-      </mat-step>
+            <button
+              id="saveDefaultSettings"
+              class="fullwidth-button"
+              mat-raised-button
+              *ngIf="canSaveSettings$ | async"
+              (click)="saveSettings()"
+            >
+              Save as default
+            </button>
+          </mat-card-content>
+        </mat-card>
 
-      <ng-container *ngIf="!(isStandalone$ | async); else standaloneExport">
-        <mat-step>
-          <ng-template matStepLabel>Done</ng-template>
-          <img class="previewimage" [src]="processing.entitySettings.preview" />
-          You set all settings and I celebrate it with this preview.
-          <br />
-          Please save them if you are done. Afterwards you may add annotations.
-          <div>
-            <button mat-button matStepperPrevious>Back</button>
-            <button mat-button (click)="saveSettings()">Save</button>
-          </div>
-        </mat-step>
-      </ng-container>
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title> Background </mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            <color-chrome (onChange)="setBackgroundColor($event.color.rgb)"></color-chrome>
+            <br />
+            <mat-slide-toggle
+              [(ngModel)]="settings.localSettings.background.effect"
+              (change)="entitySettings.loadBackgroundEffect()"
+            >
+              Gradient-Brightness Effect
+            </mat-slide-toggle>
+          </mat-card-content>
+        </mat-card>
 
-      <ng-template #standaloneExport>
-        <mat-step>
-          <ng-template matStepLabel>Export</ng-template>
-          <img class="previewimage" [src]="processing.entitySettings.preview" />
-          Your settings can now be exported and loaded in the standalone Kompakkt viewer.
-          <div>
-            <button mat-button matStepperPrevious>Back</button>
-            <button mat-button (click)="exportSettings()">Export</button>
-          </div>
-        </mat-step>
-      </ng-template>
-    </mat-vertical-stepper>
-  </div>
-</div>
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title> Lights </mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            <app-entity-feature-settings-lights></app-entity-feature-settings-lights>
+          </mat-card-content>
+        </mat-card>
+
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title> Preview & Initial Perspective </mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            Click on this image to set actual view as initial perspective.
+            <img
+              class="previewimage"
+              [src]="settings.localSettings.preview"
+              (click)="setInitialPerspectivePreview()"
+            />
+          </mat-card-content>
+        </mat-card>
+
+        <mat-card>
+          <mat-card-content>
+            <button class="fullwidth-button" mat-raised-button (click)="backToDefaultSettings()">
+              Back to Default
+            </button>
+            <button
+              class="fullwidth-button"
+              mat-raised-button
+              *ngIf="canSaveSettings$ | async"
+              (click)="saveSettings()"
+            >
+              Save as default
+            </button>
+          </mat-card-content>
+        </mat-card>
+      </div>
+
+      <div *ngIf="processing.isInUpload$ | async">
+        <mat-vertical-stepper [linear]="true" #stepper>
+          <mat-step *ngIf="processing.hasMeshSettings$ | async">
+            <app-entity-feature-settings-mesh></app-entity-feature-settings-mesh>
+            <div>
+              <button mat-button (click)="showNextAlertFirstStep()">Next</button>
+            </div>
+          </mat-step>
+
+          <mat-step>
+            <ng-template matStepLabel>Set Initial Settings</ng-template>
+            <h5>
+              Background
+              <button
+                mat-icon-button
+                (click)="backgroundToggle = !backgroundToggle"
+                matTooltip="Toggle"
+                matTooltipPosition="above"
+                type="button"
+              >
+                <mat-icon>
+                  {{ backgroundToggle ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
+                </mat-icon>
+              </button>
+            </h5>
+            <div *ngIf="backgroundToggle">
+              <color-chrome (onChange)="setBackgroundColor($event.color.rgb)"></color-chrome>
+              <br />
+              <mat-slide-toggle
+                [(ngModel)]="settings.localSettings.background.effect"
+                (change)="entitySettings.loadBackgroundEffect()"
+              >
+                Gradient-Brightness Effect
+              </mat-slide-toggle>
+            </div>
+            <h5>
+              Lights
+              <button
+                mat-icon-button
+                (click)="lightsToggle = !lightsToggle"
+                matTooltip="Toggle"
+                matTooltipPosition="above"
+                type="button"
+              >
+                <mat-icon>
+                  {{ lightsToggle ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
+                </mat-icon>
+              </button>
+            </h5>
+            <div *ngIf="lightsToggle">
+              <app-entity-feature-settings-lights></app-entity-feature-settings-lights>
+            </div>
+            <div *ngIf="(processing.mediaType$ | async) !== 'audio'">
+              <h5>
+                Preview & Initial Perspective
+                <button
+                  mat-icon-button
+                  (click)="previewToggle = !previewToggle"
+                  matTooltip="Toggle"
+                  matTooltipPosition="above"
+                  type="button"
+                >
+                  <mat-icon>
+                    {{ previewToggle ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
+                  </mat-icon>
+                </button>
+              </h5>
+              <div *ngIf="previewToggle">
+                Please select a nice and fitting camera perspective before you go on to the next
+                step. By clicking on the next button the actual view will be set as initial
+                perspective. And I will automatically produce a preview - smile!
+              </div>
+            </div>
+            <div>
+              <button mat-button (click)="nextSecondStep()">Next</button>
+            </div>
+          </mat-step>
+
+          <ng-container *ngIf="!(isStandalone$ | async); else standaloneExport">
+            <mat-step>
+              <ng-template matStepLabel>Done</ng-template>
+              <img class="previewimage" [src]="settings.localSettings.preview" />
+              You set all settings and I celebrate it with this preview.
+              <br />
+              Please save them if you are done. Afterwards you may add annotations.
+              <div>
+                <button mat-button matStepperPrevious>Back</button>
+                <button mat-button (click)="saveSettings()">Save</button>
+              </div>
+            </mat-step>
+          </ng-container>
+
+          <ng-template #standaloneExport>
+            <mat-step>
+              <ng-template matStepLabel>Export</ng-template>
+              <img class="previewimage" [src]="settings.localSettings.preview" />
+              Your settings can now be exported and loaded in the standalone Kompakkt viewer.
+              <div>
+                <button mat-button matStepperPrevious>Back</button>
+                <button mat-button (click)="exportSettings()">Export</button>
+              </div>
+            </mat-step>
+          </ng-template>
+        </mat-vertical-stepper>
+      </div>
+    </div>
+  </ng-container>
+</ng-container>

--- a/src/app/components/entity-feature-settings/entity-feature-settings.component.html
+++ b/src/app/components/entity-feature-settings/entity-feature-settings.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="settingsReady$ | async">
   <ng-container *ngIf="processing.settings$ | async as settings">
-    <div *ngIf="" id="editor-entitysettings">
+    <div id="editor-entitysettings">
       <div *ngIf="(processing.isInUpload$ | async) === false">
         <mat-card>
           <mat-card-content>

--- a/src/app/components/entity-feature-settings/entity-feature-settings.component.ts
+++ b/src/app/components/entity-feature-settings/entity-feature-settings.component.ts
@@ -68,11 +68,15 @@ export class EntityFeatureSettingsComponent {
       this.processing.fallbackEntityLoaded$,
       this.processing.compilationLoaded$,
       this.mode$,
-      this.userdata.userOwnsEntity$,
+      this.processing.entity$,
     ]).pipe(
       map(
-        ([isDefault, isFallback, isCompilationLoaded, mode, userOwnsEntity]) =>
-          !isDefault && !isFallback && !isCompilationLoaded && mode === 'edit' && userOwnsEntity,
+        ([isDefault, isFallback, isCompilationLoaded, mode, entity]) =>
+          !isDefault &&
+          !isFallback &&
+          !isCompilationLoaded &&
+          mode === 'edit' &&
+          this.userdata.doesUserOwn(entity),
       ),
     );
   }

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -47,30 +47,32 @@
     </button>
     <!-- Quality Submenu -->
     <mat-menu #quality="matMenu">
-      <button
-        mat-menu-item
-        *ngIf="qualities.high"
-        (click)="updateEntityQuality('high')"
-        [ngClass]="this.processing.entityQuality === 'high' ? 'is-active' : ''"
-      >
-        High
-      </button>
-      <button
-        mat-menu-item
-        *ngIf="qualities.medium"
-        (click)="updateEntityQuality('medium')"
-        [ngClass]="this.processing.entityQuality === 'medium' ? 'is-active' : ''"
-      >
-        Medium
-      </button>
-      <button
-        mat-menu-item
-        *ngIf="qualities.low"
-        (click)="updateEntityQuality('low')"
-        [ngClass]="this.processing.entityQuality === 'low' ? 'is-active' : ''"
-      >
-        Low
-      </button>
+      <ng-container *ngIf="processing.quality$ | async as currentQuality">
+        <button
+          mat-menu-item
+          *ngIf="qualities.high"
+          (click)="updateEntityQuality('high')"
+          [class.is-active]="currentQuality === 'high'"
+        >
+          High
+        </button>
+        <button
+          mat-menu-item
+          *ngIf="qualities.medium"
+          (click)="updateEntityQuality('medium')"
+          [class.is-active]="currentQuality === 'medium'"
+        >
+          Medium
+        </button>
+        <button
+          mat-menu-item
+          *ngIf="qualities.low"
+          (click)="updateEntityQuality('low')"
+          [class.is-active]="currentQuality === 'low'"
+        >
+          Low
+        </button>
+      </ng-container>
     </mat-menu>
     <!-- / Quality Submenu -->
   </ng-container>

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -1,8 +1,8 @@
-<div class="bottom">
+<div class="bottom" *ngIf="entity$ | async as entity">
   <div class="anchor">
     <button
       mat-icon-button
-      *ngIf="processing.entityMediaType !== 'audio'"
+      *ngIf="entity.mediaType !== 'audio'"
       matTooltip="Camera settings"
       matTooltipPosition="above"
       (click)="cameraSettings.toggle()"
@@ -12,7 +12,7 @@
     <app-camera-settings #cameraSettings></app-camera-settings>
   </div>
 
-  <ng-container *ngIf="userData">
+  <!--   <ng-container *ngIf="userData">
     <button
       mat-icon-button
       *ngIf="loginRequired && !isAuthenticated"
@@ -33,45 +33,47 @@
     matTooltipPosition="above"
   >
     <mat-icon>sentiment_very_satisfied</mat-icon>
-  </button>
+  </button> -->
 
-  <button
-    mat-icon-button
-    *ngIf="getAvailableQuality('high') && getAvailableQuality('medium')"
-    [matMenuTriggerFor]="quality"
-    matTooltip="Quality"
-    matTooltipPosition="above"
-  >
-    <mat-icon>high_quality</mat-icon>
-  </button>
-  <!-- Quality Submenu -->
-  <mat-menu #quality="matMenu">
+  <ng-container *ngIf="qualities$ | async as qualities">
     <button
-      mat-menu-item
-      *ngIf="getAvailableQuality('high')"
-      (click)="updateEntityQuality('high')"
-      [ngClass]="this.processing.entityQuality === 'high' ? 'is-active' : ''"
+      mat-icon-button
+      *ngIf="qualities.high && qualities.medium"
+      [matMenuTriggerFor]="quality"
+      matTooltip="Quality"
+      matTooltipPosition="above"
     >
-      High
+      <mat-icon>high_quality</mat-icon>
     </button>
-    <button
-      mat-menu-item
-      *ngIf="getAvailableQuality('medium')"
-      (click)="updateEntityQuality('medium')"
-      [ngClass]="this.processing.entityQuality === 'medium' ? 'is-active' : ''"
-    >
-      Medium
-    </button>
-    <button
-      mat-menu-item
-      *ngIf="getAvailableQuality('low')"
-      (click)="updateEntityQuality('low')"
-      [ngClass]="this.processing.entityQuality === 'low' ? 'is-active' : ''"
-    >
-      Low
-    </button>
-  </mat-menu>
-  <!-- / Quality Submenu -->
+    <!-- Quality Submenu -->
+    <mat-menu #quality="matMenu">
+      <button
+        mat-menu-item
+        *ngIf="qualities.high"
+        (click)="updateEntityQuality('high')"
+        [ngClass]="this.processing.entityQuality === 'high' ? 'is-active' : ''"
+      >
+        High
+      </button>
+      <button
+        mat-menu-item
+        *ngIf="qualities.medium"
+        (click)="updateEntityQuality('medium')"
+        [ngClass]="this.processing.entityQuality === 'medium' ? 'is-active' : ''"
+      >
+        Medium
+      </button>
+      <button
+        mat-menu-item
+        *ngIf="qualities.low"
+        (click)="updateEntityQuality('low')"
+        [ngClass]="this.processing.entityQuality === 'low' ? 'is-active' : ''"
+      >
+        Low
+      </button>
+    </mat-menu>
+    <!-- / Quality Submenu -->
+  </ng-container>
 
   <button
     mat-icon-button

--- a/src/app/components/menu/menu.component.ts
+++ b/src/app/components/menu/menu.component.ts
@@ -1,13 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-
+import fscreen from 'fscreen';
+import { firstValueFrom, map } from 'rxjs';
 import { BabylonService } from '../../services/babylon/babylon.service';
 import { MessageService } from '../../services/message/message.service';
 import { ProcessingService } from '../../services/processing/processing.service';
 import { UserdataService } from '../../services/userdata/userdata.service';
-
-import { IEntity } from 'src/common';
-
-import fscreen from 'fscreen';
 
 @Component({
   selector: 'app-menu',
@@ -17,27 +14,29 @@ import fscreen from 'fscreen';
 export class MenuComponent implements OnInit {
   public fullscreen = !!fscreen.fullscreenElement;
   public fullscreenCapable = fscreen.fullscreenEnabled;
-  private entity: IEntity | undefined;
 
   constructor(
     public processing: ProcessingService,
     public babylon: BabylonService,
     public userdata: UserdataService,
     private message: MessageService,
-  ) {
-    this.processing.entity$.subscribe(entity => (this.entity = entity));
+  ) {}
+
+  get entity$() {
+    return this.processing.entity$;
   }
 
-  get userData() {
-    return this.userdata.userData;
-  }
-
-  get loginRequired() {
-    return this.userdata.loginRequired;
-  }
-
-  get isAuthenticated() {
-    return this.userdata.authenticatedUser;
+  get qualities$() {
+    return this.entity$.pipe(
+      map(entity => {
+        if (!entity) return undefined;
+        return {
+          low: entity.processed.low !== entity.processed.medium,
+          medium: entity.processed.medium !== entity.processed.low,
+          high: entity.processed.high !== entity.processed.medium,
+        };
+      }),
+    );
   }
 
   ngOnInit() {
@@ -47,31 +46,18 @@ export class MenuComponent implements OnInit {
     );
   }
 
-  getAvailableQuality(quality: string) {
-    if (!this.entity) return false;
-    switch (quality) {
-      case 'low':
-        return this.entity.processed.low !== this.entity.processed.medium;
-      case 'medium':
-        return this.entity.processed.medium !== this.entity.processed.low;
-      case 'high':
-        return this.entity.processed.high !== this.entity.processed.medium;
-      default:
-        return false;
-    }
-  }
-
-  updateEntityQuality(quality: string) {
+  public async updateEntityQuality(quality: string) {
+    const entity = await firstValueFrom(this.entity$);
     if (this.processing.entityQuality !== quality) {
       this.processing.updateEntityQuality(quality);
-      if (!this.entity?.processed) {
+      if (!entity?.processed) {
         throw new Error(
           'The object is not available and unfortunately ' + 'I can not update the entityQuality.',
         );
       }
-      const qualities: any = this.entity?.processed ?? {};
+      const qualities: any = entity?.processed ?? {};
       if (!!qualities[this.processing.entityQuality]) {
-        this.processing.loadEntity(this.entity);
+        this.processing.loadEntity(entity);
       } else {
         throw new Error('Entity entityQuality is not available.');
       }

--- a/src/app/components/menu/menu.component.ts
+++ b/src/app/components/menu/menu.component.ts
@@ -3,7 +3,7 @@ import fscreen from 'fscreen';
 import { firstValueFrom, map } from 'rxjs';
 import { BabylonService } from '../../services/babylon/babylon.service';
 import { MessageService } from '../../services/message/message.service';
-import { ProcessingService } from '../../services/processing/processing.service';
+import { ProcessingService, QualitySetting } from '../../services/processing/processing.service';
 import { UserdataService } from '../../services/userdata/userdata.service';
 
 @Component({
@@ -46,22 +46,14 @@ export class MenuComponent implements OnInit {
     );
   }
 
-  public async updateEntityQuality(quality: string) {
+  public async updateEntityQuality(nextQuality: QualitySetting) {
+    const currentQuality = this.processing.quality$.getValue();
     const entity = await firstValueFrom(this.entity$);
-    if (this.processing.entityQuality !== quality) {
-      this.processing.updateEntityQuality(quality);
-      if (!entity?.processed) {
-        throw new Error(
-          'The object is not available and unfortunately ' + 'I can not update the entityQuality.',
-        );
-      }
-      const qualities: any = entity?.processed ?? {};
-      if (!!qualities[this.processing.entityQuality]) {
-        this.processing.loadEntity(entity);
-      } else {
-        throw new Error('Entity entityQuality is not available.');
-      }
-    }
+    if (nextQuality === currentQuality) return;
+    if (!entity?.processed?.[nextQuality]) return;
+
+    this.processing.updateEntityQuality(nextQuality);
+    this.processing.loadEntity(entity);
   }
 
   toggleFullscreen() {

--- a/src/app/components/scene/scene.component.html
+++ b/src/app/components/scene/scene.component.html
@@ -1,5 +1,5 @@
-<ng-container *ngIf="isReady">
-  <div *ngFor="let annotation of currentAnnotations$ | async">
+<ng-container *ngIf="processing.bootstrapped$ | async">
+  <div *ngFor="let annotation of annotations.currentAnnotations$ | async">
     <app-annotation [annotation]="annotation"></app-annotation>
   </div>
   <app-annotationwalkthrough></app-annotationwalkthrough>

--- a/src/app/components/scene/scene.component.ts
+++ b/src/app/components/scene/scene.component.ts
@@ -1,5 +1,4 @@
 import { AfterViewInit, Component, HostListener, ViewContainerRef } from '@angular/core';
-
 import { AnnotationService } from '../../services/annotation/annotation.service';
 import { BabylonService } from '../../services/babylon/babylon.service';
 import { ProcessingService } from '../../services/processing/processing.service';
@@ -15,25 +14,16 @@ export class SceneComponent implements AfterViewInit {
     this.babylon.resize();
   }
 
-  public isReady = false;
-
-  public currentAnnotations$ = this.annotations.currentAnnotations$;
-
   constructor(
     private babylon: BabylonService,
     public processing: ProcessingService,
     public annotations: AnnotationService,
     private viewContainerRef: ViewContainerRef,
-  ) {
-    setTimeout(() => {
-      this.processing.bootstrapped$.subscribe(change => (this.isReady = change));
-    }, 0);
-  }
+  ) {}
 
   private setupCanvas() {
     this.babylon.attachCanvas(this.viewContainerRef);
-    this.processing.bootstrap();
-    this.babylon.resize();
+    this.processing.bootstrap().then(() => this.babylon.resize());
   }
 
   ngAfterViewInit() {

--- a/src/app/components/sidenav-menu/sidenav-menu.component.html
+++ b/src/app/components/sidenav-menu/sidenav-menu.component.html
@@ -25,7 +25,7 @@
       </mat-icon>
     </button>
   </div>
-  <div *ngIf="processing.showCompilationBrowser$ | async">
+  <div *ngIf="processing.compilationLoaded$ | async">
     <button
       mat-icon-button
       (click)="overlay.toggleSidenav('compilationBrowser')"

--- a/src/app/components/sidenav-menu/sidenav-menu.component.ts
+++ b/src/app/components/sidenav-menu/sidenav-menu.component.ts
@@ -15,9 +15,9 @@ export class SidenavMenuComponent implements OnInit {
 
   constructor(public overlay: OverlayService, public processing: ProcessingService) {
     setTimeout(() => {
-      this.overlay.sidenavMode$.subscribe(mode => (this.mode = mode));
-      this.overlay.sidenav$.subscribe(state => {
-        this.isOpen = state;
+      this.overlay.sidenav$.subscribe(({ mode, open }) => {
+        this.mode = mode;
+        this.isOpen = open;
       });
     }, 0);
   }

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -17,6 +17,7 @@ export class SidenavComponent implements OnInit {
   constructor(public overlay: OverlayService) {
     setTimeout(() => {
       this.overlay.sidenav$.subscribe(({ mode, open }) => {
+        console.log(mode, open);
         this.mode = mode;
         this.isOpen = open;
         this.isReady = this.isOpen && !!this.mode;

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -16,9 +16,9 @@ export class SidenavComponent implements OnInit {
 
   constructor(public overlay: OverlayService) {
     setTimeout(() => {
-      this.overlay.sidenavMode$.subscribe(mode => (this.mode = mode));
-      this.overlay.sidenav$.subscribe(state => {
-        this.isOpen = state;
+      this.overlay.sidenav$.subscribe(({ mode, open }) => {
+        this.mode = mode;
+        this.isOpen = open;
         this.isReady = this.isOpen && !!this.mode;
       });
     }, 0);

--- a/src/app/services/annotation/annotation.service.ts
+++ b/src/app/services/annotation/annotation.service.ts
@@ -458,9 +458,10 @@ export class AnnotationService {
     let newAnnotation = _annotation;
     newAnnotation.lastModificationDate = new Date().toISOString();
     const isCompilationLoaded = await firstValueFrom(this.processing.compilationLoaded$);
+    const compilation = await firstValueFrom(this.processing.compilation$);
     const isDefault = await firstValueFrom(this.processing.defaultEntityLoaded$);
     const isFallback = await firstValueFrom(this.processing.fallbackEntityLoaded$);
-    const userOwnsCompilation = await firstValueFrom(this.userdata.userOwnsCompilation$);
+    const userOwnsCompilation = compilation && this.userdata.doesUserOwn(compilation);
     if (!isFallback && !isDefault) {
       const isOwner =
         this.userdata.isAnnotationOwner(_annotation) ||

--- a/src/app/services/annotation/annotation.service.ts
+++ b/src/app/services/annotation/annotation.service.ts
@@ -14,8 +14,8 @@ import { DialogGetUserDataComponent } from '../../components/dialogs/dialog-get-
 import { DialogShareAnnotationComponent } from '../../components/dialogs/dialog-share-annotation/dialog-share-annotation.component';
 import { BabylonService } from '../babylon/babylon.service';
 import { BackendService } from '../backend/backend.service';
-import { DataService } from '../data/data.service';
 import { MessageService } from '../message/message.service';
+import { PouchService } from '../pouch/pouch.service';
 import { ProcessingService } from '../processing/processing.service';
 import { UserdataService } from '../userdata/userdata.service';
 import { createMarker } from './visual3DElements';
@@ -59,7 +59,7 @@ export class AnnotationService {
   );
 
   constructor(
-    private data: DataService,
+    private pouch: PouchService,
     private babylon: BabylonService,
     private backend: BackendService,
     private message: MessageService,
@@ -232,7 +232,7 @@ export class AnnotationService {
         _localAnnotation => _localAnnotation._id === annotation._id,
       );
       if (!localAnnotation) {
-        await this.data.updateAnnotation(annotation);
+        await this.pouch.updateAnnotation(annotation);
         localAnnotations.push(annotation);
       }
     }
@@ -277,7 +277,7 @@ export class AnnotationService {
           unsorted.push(annotation);
         } else {
           // Update local DB
-          await this.data.updateAnnotation(serverAnnotation);
+          await this.pouch.updateAnnotation(serverAnnotation);
           localAnnotations.splice(
             localAnnotations.findIndex(ann => ann._id === annotation._id),
             1,
@@ -301,7 +301,7 @@ export class AnnotationService {
         } else {
           // Nicht local last editor === creator === ich
           // Annotation local löschen
-          await this.data.deleteAnnotation(annotation._id.toString());
+          await this.pouch.deleteAnnotation(annotation._id.toString());
           localAnnotations.splice(localAnnotations.findIndex(ann => ann._id === annotation._id));
         }
       }
@@ -446,7 +446,7 @@ export class AnnotationService {
         .catch((errorMessage: any) => {
           console.log(errorMessage);
         });
-      this.data.updateAnnotation(newAnnotation);
+      this.pouch.updateAnnotation(newAnnotation);
     }
     this.drawMarker(newAnnotation);
     this.annotations$.next(this.annotations$.getValue().concat(newAnnotation));
@@ -475,7 +475,7 @@ export class AnnotationService {
             console.log(errorMessage);
           });
       }
-      this.data.updateAnnotation(newAnnotation);
+      this.pouch.updateAnnotation(newAnnotation);
     }
     const arr = this.annotations$.getValue();
     arr.splice(
@@ -503,7 +503,7 @@ export class AnnotationService {
         this.redrawMarker();
         this.annotations$.next(arr);
         if (!isFallback && !isDefault) {
-          this.data.deleteAnnotation(_annotation._id.toString());
+          this.pouch.deleteAnnotation(_annotation._id.toString());
           this.deleteAnnotationFromServer(_annotation._id.toString());
         }
       }
@@ -566,7 +566,7 @@ export class AnnotationService {
 
   private async fetchAnnotations(entity: string, compilation?: string): Promise<IAnnotation[]> {
     return new Promise<IAnnotation[]>(async (resolve, _) => {
-      const annotationList: IAnnotation[] = await this.data.findAnnotations(
+      const annotationList: IAnnotation[] = await this.pouch.findAnnotations(
         entity,
         compilation ? compilation : '',
       );

--- a/src/app/services/annotation/annotation.service.ts
+++ b/src/app/services/annotation/annotation.service.ts
@@ -2,18 +2,10 @@ import { moveItemInArray } from '@angular/cdk/drag-drop';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { IAnnotation, ICompilation, IEntity, IVector3, isAnnotation } from 'src/common';
-import {
-  ActionManager,
-  ExecuteCodeAction,
-  Mesh,
-  Tags,
-  Vector3,
-  PickingInfo,
-} from '@babylonjs/core';
-import { map } from 'rxjs/operators';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
-
+import { ActionManager, ExecuteCodeAction, PickingInfo, Tags, Vector3 } from '@babylonjs/core';
+import { BehaviorSubject, combineLatest, firstValueFrom, fromEvent, ReplaySubject } from 'rxjs';
+import { distinct, map } from 'rxjs/operators';
+import { IAnnotation, isAnnotation, IVector3 } from 'src/common';
 import { annotationFallback, annotationLogo } from '../../../assets/annotations/annotations';
 import { environment } from '../../../environments/environment';
 // tslint:disable-next-line:max-line-length
@@ -26,7 +18,6 @@ import { DataService } from '../data/data.service';
 import { MessageService } from '../message/message.service';
 import { ProcessingService } from '../processing/processing.service';
 import { UserdataService } from '../userdata/userdata.service';
-
 import { createMarker } from './visual3DElements';
 
 const isDefaultAnnotation = (annotation: IAnnotation) =>
@@ -53,23 +44,19 @@ const getVector = ({ x, y, z, _x, _y, _z }: IAmbiguousVector) =>
   providedIn: 'root',
 })
 export class AnnotationService {
-  // What is actually going on and what is loaded? external Infos
-  private entity: IEntity | undefined;
-  private meshes: Mesh[] = [];
-  public compilation: ICompilation | undefined;
-  private isStandalone = false;
-
   // All about annotations
-  private selectedAnnotation = new BehaviorSubject('');
-  public isSelectedAnnotation = this.selectedAnnotation.asObservable();
-  private editModeAnnotation = new BehaviorSubject('');
-  public isEditModeAnnotation = this.editModeAnnotation.asObservable();
-  private annotations = new BehaviorSubject<IAnnotation[]>([]);
-  public annotations$ = this.annotations.asObservable();
+  public selectedAnnotation$ = new BehaviorSubject('');
+  public editModeAnnotation$ = new BehaviorSubject('');
+  public annotations$ = new BehaviorSubject<IAnnotation[]>([]);
 
   public isAnnotationMode$ = new BehaviorSubject(false);
 
   private defaultOffset = 0;
+
+  public picked$ = new ReplaySubject<PickingInfo>();
+  public debouncedPicked$ = this.picked$.pipe(
+    distinct(({ pickedPoint }) => JSON.stringify(pickedPoint)),
+  );
 
   constructor(
     private data: DataService,
@@ -80,32 +67,19 @@ export class AnnotationService {
     private dialog: MatDialog,
     private userdata: UserdataService,
   ) {
-    // What is actually going on and what is loaded? external Infos
-    this.processing.entity$.subscribe(entity => {
-      this.entity = entity;
+    this.debouncedPicked$.subscribe(result => {
+      this.createNewAnnotation(result);
     });
 
-    this.processing.meshes$.subscribe(meshes => {
-      this.meshes = meshes;
+    this.processing.state$.subscribe(({ entity }) => {
+      if (entity) this.loadAnnotations();
     });
 
-    this.processing.compilation$.subscribe(compilation => {
-      this.compilation = compilation;
-    });
-
-    this.processing.isStandalone$.subscribe(isStandalone => {
-      this.isStandalone = isStandalone;
-    });
-
-    this.processing.loadAnnotations.subscribe((load: boolean) => {
-      if (load) this.loadAnnotations();
-    });
-
-    this.processing.initialiseEntityForAnnotating.subscribe((init: boolean) => {
+    this.processing.isAnnotatingFeatured$.subscribe((init: boolean) => {
       if (init) this.initializeAnnotationMode();
     });
 
-    this.processing.setAnnotationAllowance.subscribe((allowance: boolean) => {
+    this.processing.hasAnnotationAllowance$.subscribe((allowance: boolean) => {
       console.log('ich setze das mesh als', allowance);
       this.setAnnotationMode(allowance);
     });
@@ -117,10 +91,6 @@ export class AnnotationService {
     this.currentAnnotations$.subscribe(() => this.redrawMarker());
   }
 
-  get isHomepageEntity() {
-    return this.entity?._id === 'default' && !this.processing.mode;
-  }
-
   get defaultAnnotations$() {
     return this.annotations$.pipe(map(arr => arr.filter(isDefaultAnnotation)));
   }
@@ -130,10 +100,10 @@ export class AnnotationService {
   }
 
   get currentAnnotations$() {
-    return this.annotations$.pipe(
-      map(arr =>
-        arr.filter(annotation =>
-          this.processing.compilationLoaded
+    return combineLatest([this.annotations$, this.processing.compilationLoaded$]).pipe(
+      map(([annotations, isCompilationLoaded]) =>
+        annotations.filter(annotation =>
+          isCompilationLoaded
             ? isCompilationAnnotation(annotation)
             : isDefaultAnnotation(annotation),
         ),
@@ -146,29 +116,33 @@ export class AnnotationService {
     // with defaults first and compilation following
     // we can calculate the offset if needed
     const arr = await this.getSortedAnnotations();
-    const offset = this.processing.compilationLoaded ? this.defaultOffset : 0;
+    const isCompilationLoaded = await firstValueFrom(this.processing.compilationLoaded$);
+    const offset = isCompilationLoaded ? this.defaultOffset : 0;
     moveItemInArray(arr, from_index + offset, to_index + offset);
-    this.annotations.next(arr);
+    this.annotations$.next(arr);
     await this.changedRankingPositions();
   }
 
   public async loadAnnotations() {
-    if (!this.entity) {
+    const entity = await firstValueFrom(this.processing.entity$);
+    const meshes = await firstValueFrom(this.processing.meshes$);
+    const isStandalone = await firstValueFrom(this.processing.isStandalone$);
+    const isDefault = await firstValueFrom(this.processing.defaultEntityLoaded$);
+    const isFallback = await firstValueFrom(this.processing.fallbackEntityLoaded$);
+    const isAnnotatingFeatured = await firstValueFrom(this.processing.isAnnotatingFeatured$);
+    if (!entity) {
       throw new Error('Entity missing');
     }
-    Tags.AddTagsTo(this.meshes, this.entity._id.toString());
-    this.selectedAnnotation.next('');
-    this.editModeAnnotation.next('');
-    this.annotations.next([]);
+    Tags.AddTagsTo(meshes, entity._id.toString());
+    this.selectedAnnotation$.next('');
+    this.editModeAnnotation$.next('');
+    this.annotations$.next([]);
 
-    const loadFromServer =
-      !this.isStandalone &&
-      !this.processing.defaultEntityLoaded &&
-      !this.processing.fallbackEntityLoaded;
+    const loadFromServer = !isStandalone && !isDefault && !isFallback;
 
     if (loadFromServer) {
       // Filter null/undefined annotations
-      const serverAnnotations = this.getAnnotationsfromServerDB().filter(
+      const serverAnnotations = (await this.getAnnotationsfromServerDB()).filter(
         annotation => annotation && annotation._id && annotation.lastModificationDate,
       );
       const pouchAnnotations = (await this.getAnnotationsfromLocalDB()).filter(
@@ -177,7 +151,7 @@ export class AnnotationService {
       // Update and sort local
       await this.updateLocalDB(pouchAnnotations, serverAnnotations);
       const updated = await this.updateAnnotationList(pouchAnnotations, serverAnnotations);
-      this.annotations.next(updated);
+      this.annotations$.next(updated);
 
       // above updateAnnotationList call already checks if values in pouchAnnotations changed
       // and sends update requests to server.
@@ -189,37 +163,40 @@ export class AnnotationService {
         await this.sortAnnotations();
       }
     } else {
-      if (this.processing.fallbackEntityLoaded) {
-        this.annotations.next([annotationFallback]);
+      if (isFallback) {
+        this.annotations$.next([annotationFallback]);
       }
-      if (this.processing.defaultEntityLoaded) {
-        if (this.processing.annotatingFeatured && annotationLogo.length) {
-          this.annotations.next(annotationLogo);
+      if (isDefault) {
+        if (isAnnotatingFeatured && annotationLogo.length) {
+          this.annotations$.next(annotationLogo);
         }
       }
-      if (this.isStandalone) {
-        this.annotations.next(Object.values(this.entity.annotations) as IAnnotation[]);
+      if (isStandalone) {
+        this.annotations$.next(Object.values(entity.annotations) as IAnnotation[]);
       }
-      const annotations = await firstValueFrom(this.annotations);
+      const annotations = this.annotations$.getValue();
       if (annotations.length > 0) {
-        this.selectedAnnotation.next(annotations[0]._id.toString());
+        this.selectedAnnotation$.next(annotations[0]._id.toString());
       }
     }
   }
 
-  private getAnnotationsfromServerDB() {
+  private async getAnnotationsfromServerDB() {
+    const entity = await firstValueFrom(this.processing.entity$);
+    const compilation = await firstValueFrom(this.processing.compilation$);
+    const isCompilationLoaded = await firstValueFrom(this.processing.compilationLoaded$);
     const serverAnnotations: IAnnotation[] = [];
     // Annotationen vom Server des aktuellen Entityls...
-    for (const id in this.entity?.annotations) {
-      const anno = this.entity?.annotations[id];
+    for (const id in entity?.annotations) {
+      const anno = entity?.annotations[id];
       if (!isAnnotation(anno)) continue;
       serverAnnotations.push(anno);
     }
     // ...und der aktuellen Compilation (if existing)
-    if (this.entity?._id && this.processing.compilationLoaded && this.compilation?.annotations) {
-      const entityID = this.entity._id;
-      for (const id in this.compilation?.annotations) {
-        const anno = this.compilation?.annotations[id];
+    if (entity?._id && isCompilationLoaded && compilation?.annotations) {
+      const entityID = entity._id;
+      for (const id in compilation?.annotations) {
+        const anno = compilation?.annotations[id];
         if (!isAnnotation(anno)) continue;
         if (anno?.target?.source?.relatedEntity !== entityID) continue;
         serverAnnotations.push(anno);
@@ -230,15 +207,18 @@ export class AnnotationService {
   }
 
   private async getAnnotationsfromLocalDB() {
-    let pouchAnnotations: IAnnotation[] = this.entity
-      ? await this.fetchAnnotations(this.entity._id.toString())
+    const entity = await firstValueFrom(this.processing.entity$);
+    const compilation = await firstValueFrom(this.processing.compilation$);
+    const isCompilationLoaded = await firstValueFrom(this.processing.compilationLoaded$);
+    let pouchAnnotations: IAnnotation[] = entity
+      ? await this.fetchAnnotations(entity._id.toString())
       : [];
     // Annotationen aus PouchDB des aktuellen Entityls und der aktuellen Compilation (if existing)
 
-    if (this.processing.compilationLoaded) {
+    if (isCompilationLoaded) {
       const _compilationAnnotations =
-        this.entity && this.compilation
-          ? await this.fetchAnnotations(this.entity._id.toString(), this.compilation._id.toString())
+        entity && compilation
+          ? await this.fetchAnnotations(entity._id.toString(), compilation._id.toString())
           : [];
       pouchAnnotations = pouchAnnotations.concat(_compilationAnnotations);
     }
@@ -264,14 +244,11 @@ export class AnnotationService {
     serverAnnotations: IAnnotation[],
   ) {
     const unsorted: IAnnotation[] = [];
+    const userData = await firstValueFrom(this.userdata.userData$);
     // Durch alle Annotationen der lokalen DB
     for (const annotation of localAnnotations) {
-      const isLastModifiedByMe = this.userdata.userData
-        ? annotation.lastModifiedBy._id === this.userdata.userData._id
-        : false;
-      const isCreatedByMe = this.userdata.userData
-        ? annotation.creator._id === this.userdata.userData._id
-        : false;
+      const isLastModifiedByMe = userData ? annotation.lastModifiedBy._id === userData._id : false;
+      const isCreatedByMe = userData ? annotation.creator._id === userData._id : false;
 
       // Finde die Annotaion in den Server Annotationen
       const serverAnnotation = serverAnnotations.find(
@@ -342,40 +319,36 @@ export class AnnotationService {
   }
 
   private async sortAnnotations() {
-    this.annotations.next(await this.getSortedAnnotations());
+    this.annotations$.next(await this.getSortedAnnotations());
 
     await this.changedRankingPositions();
   }
 
   // Die Annotationsfunktionalität wird zue aktuellen Entity hinzugefügt
   public initializeAnnotationMode() {
-    this.babylon.getCanvas().addEventListener('dblclick', () => {
+    fromEvent<MouseEvent>(this.babylon.getCanvas(), 'dblclick').subscribe(() => {
       const scene = this.babylon.getScene();
       const result = scene.pick(scene.pointerX, scene.pointerY, mesh => mesh.isPickable);
-      if (!result) return;
-      console.log('Picked', result);
-      this.createNewAnnotation(result);
+      if (!result?.pickedPoint) return;
+      this.picked$.next(result);
     });
+
     this.setAnnotationMode(false);
   }
 
   // Das aktuelle Entityl wird anklickbar und damit annotierbar
-  private setAnnotationMode(value: boolean) {
-    if (
-      this.processing.entityMediaType === 'video' ||
-      this.processing.entityMediaType === 'audio'
-    ) {
-      return;
-    }
+  private async setAnnotationMode(value: boolean) {
+    const mediaType = await firstValueFrom(this.processing.mediaType$);
+    if (mediaType === 'video' || mediaType === 'audio') return;
+    const meshes = await firstValueFrom(this.processing.meshes$);
     this.isAnnotationMode$.next(value);
     if (value) {
       this.babylon.getCanvas().classList.add('annotation-mode');
     } else {
       this.babylon.getCanvas().classList.remove('annotation-mode');
     }
-    for (const mesh of this.meshes) {
+    for (const mesh of meshes) {
       if (mesh.name === '__root__') continue; // Skip GlTF root node
-      console.log('Mesh', mesh);
       mesh.isPickable = value;
     }
   }
@@ -383,32 +356,30 @@ export class AnnotationService {
   public async createNewAnnotation(result: PickingInfo) {
     const camera = this.babylon.cameraManager.getInitialPosition();
     const currentAnnotations = await firstValueFrom(this.currentAnnotations$);
+    const entity = await firstValueFrom(this.processing.entity$);
+    const compilation = await firstValueFrom(this.processing.compilation$);
+    const isCompilationLoaded = await firstValueFrom(this.processing.compilationLoaded$);
+    const userdata = await firstValueFrom(this.userdata.userData$);
 
     this.babylon.createPreviewScreenshot().then(detailScreenshot => {
-      if (!this.entity) {
-        throw new Error(`this.entity not defined: ${this.entity}`);
+      if (!entity) {
+        throw new Error(`this.entity not defined: ${entity}`);
       }
       const generatedId = this.backend.generateEntityId();
 
-      const personName = this.userdata.userData ? this.userdata.userData.fullname : 'guest';
-      const personID = this.userdata.userData
-        ? this.userdata.userData._id
-        : this.userdata.guestUserData
-        ? this.userdata.guestUserData._id
-        : 'guest';
+      const personName = userdata ? userdata.fullname : 'guest';
+      const personID = userdata ? userdata._id : 'guest';
 
       const referencePoint = result.pickedPoint!;
       const referenceNormal = result.getNormal(true, true)!;
 
       const relatedCompilation =
-        this.processing.compilationLoaded && this.compilation
-          ? this.compilation._id.toString()
-          : '';
+        isCompilationLoaded && compilation ? compilation._id.toString() : '';
 
       const { position, target, cameraType } = camera;
 
       const newAnnotation: IAnnotation = {
-        validated: !this.processing.compilationLoaded,
+        validated: !isCompilationLoaded,
         _id: generatedId,
         identifier: generatedId,
         ranking: currentAnnotations.length + 1,
@@ -446,7 +417,7 @@ export class AnnotationService {
         },
         target: {
           source: {
-            relatedEntity: this.entity._id.toString(),
+            relatedEntity: entity._id.toString(),
             relatedCompilation,
           },
           selector: {
@@ -459,13 +430,13 @@ export class AnnotationService {
     });
   }
 
-  private add(_annotation: IAnnotation): void {
+  private async add(_annotation: IAnnotation) {
     let newAnnotation = _annotation;
     newAnnotation.lastModificationDate = new Date().toISOString();
-    const updateBackend =
-      !this.isStandalone &&
-      !this.processing.defaultEntityLoaded &&
-      !this.processing.fallbackEntityLoaded;
+    const isStandalone = await firstValueFrom(this.processing.isStandalone$);
+    const isDefault = await firstValueFrom(this.processing.defaultEntityLoaded$);
+    const isFallback = await firstValueFrom(this.processing.fallbackEntityLoaded$);
+    const updateBackend = !isStandalone && !isDefault && !isFallback;
     if (updateBackend) {
       this.backend
         .updateAnnotation(_annotation)
@@ -478,18 +449,22 @@ export class AnnotationService {
       this.data.updateAnnotation(newAnnotation);
     }
     this.drawMarker(newAnnotation);
-    this.annotations.next(this.annotations.getValue().concat(newAnnotation));
-    this.selectedAnnotation.next(newAnnotation._id.toString());
-    this.editModeAnnotation.next(newAnnotation._id.toString());
+    this.annotations$.next(this.annotations$.getValue().concat(newAnnotation));
+    this.selectedAnnotation$.next(newAnnotation._id.toString());
+    this.editModeAnnotation$.next(newAnnotation._id.toString());
   }
 
-  public updateAnnotation(_annotation: IAnnotation) {
+  public async updateAnnotation(_annotation: IAnnotation) {
     let newAnnotation = _annotation;
     newAnnotation.lastModificationDate = new Date().toISOString();
-    if (!this.processing.fallbackEntityLoaded && !this.processing.defaultEntityLoaded) {
+    const isCompilationLoaded = await firstValueFrom(this.processing.compilationLoaded$);
+    const isDefault = await firstValueFrom(this.processing.defaultEntityLoaded$);
+    const isFallback = await firstValueFrom(this.processing.fallbackEntityLoaded$);
+    const userOwnsCompilation = await firstValueFrom(this.userdata.userOwnsCompilation$);
+    if (!isFallback && !isDefault) {
       const isOwner =
         this.userdata.isAnnotationOwner(_annotation) ||
-        (this.processing.compilationLoaded && this.userdata.userOwnsCompilation);
+        (isCompilationLoaded && userOwnsCompilation);
       if (isOwner) {
         this.backend
           .updateAnnotation(_annotation)
@@ -502,20 +477,22 @@ export class AnnotationService {
       }
       this.data.updateAnnotation(newAnnotation);
     }
-    const arr = this.annotations.getValue();
+    const arr = this.annotations$.getValue();
     arr.splice(
       arr.findIndex(ann => ann._id === _annotation._id),
       1,
       newAnnotation,
     );
-    this.annotations.next(arr);
+    this.annotations$.next(arr);
   }
 
-  public deleteAnnotation(_annotation: IAnnotation) {
+  public async deleteAnnotation(_annotation: IAnnotation) {
+    const isDefault = await firstValueFrom(this.processing.defaultEntityLoaded$);
+    const isFallback = await firstValueFrom(this.processing.fallbackEntityLoaded$);
     if (this.userdata.isAnnotationOwner(_annotation)) {
       this.setSelectedAnnotation('');
       this.setEditModeAnnotation('');
-      const arr = this.annotations.getValue();
+      const arr = this.annotations$.getValue();
       const index = arr.findIndex(ann => ann._id === _annotation._id);
       if (index !== -1) {
         arr.splice(
@@ -524,8 +501,8 @@ export class AnnotationService {
         );
         this.changedRankingPositions();
         this.redrawMarker();
-        this.annotations.next(arr);
-        if (!this.processing.fallbackEntityLoaded && !this.processing.defaultEntityLoaded) {
+        this.annotations$.next(arr);
+        if (!isFallback && !isDefault) {
           this.data.deleteAnnotation(_annotation._id.toString());
           this.deleteAnnotationFromServer(_annotation._id.toString());
         }
@@ -535,27 +512,24 @@ export class AnnotationService {
     }
   }
 
-  public deleteAnnotationFromServer(annotationId: string) {
-    const username = this.userdata.loginData.username;
-    const password = this.userdata.loginData.password;
+  public async deleteAnnotationFromServer(annotationId: string) {
+    const loginData = await firstValueFrom(this.userdata.loginData$);
+    if (!loginData) return this.passwordDialog(annotationId);
+    const { username, password } = loginData;
 
-    if (username === '' || password === '') {
-      this.passwordDialog(annotationId);
-    } else {
-      this.backend
-        .deleteRequest(annotationId, 'annotation', username, password)
-        .then(() => {
-          this.message.info('Deleted from Server');
-        })
-        .catch((errorMessage: HttpErrorResponse) => {
-          if (errorMessage.status === 401) {
-            this.message.info('Permission denied');
-            this.passwordDialog(annotationId);
-          } else {
-            this.message.error('Annotation can not be deleted from Server.');
-          }
-        });
-    }
+    this.backend
+      .deleteRequest(annotationId, 'annotation', username, password)
+      .then(() => {
+        this.message.info('Deleted from Server');
+      })
+      .catch((errorMessage: HttpErrorResponse) => {
+        if (errorMessage.status === 401) {
+          this.message.info('Permission denied');
+          this.passwordDialog(annotationId);
+        } else {
+          this.message.error('Annotation can not be deleted from Server.');
+        }
+      });
   }
 
   public passwordDialog(annotationId: string) {
@@ -579,9 +553,10 @@ export class AnnotationService {
     // Decide whether we iterate over the first part of this.annotations
     // containing all the default annotations or to iterate over the second part
     // containing all of the compilation annotations
-    const arr = this.annotations.getValue();
-    const offset = this.processing.compilationLoaded ? this.defaultOffset : 0;
-    const length = this.processing.compilationLoaded ? arr.length : this.defaultOffset;
+    const arr = this.annotations$.getValue();
+    const isCompilationLoaded = await firstValueFrom(this.processing.compilationLoaded$);
+    const offset = isCompilationLoaded ? this.defaultOffset : 0;
+    const length = isCompilationLoaded ? arr.length : this.defaultOffset;
     for (let i = offset; i < length; i++) {
       const annotation = arr[i];
       if (!annotation._id) continue;
@@ -654,7 +629,7 @@ export class AnnotationService {
   public async setSelectedAnnotation(id: string) {
     const arr = await firstValueFrom(this.currentAnnotations$);
     const selectedAnnotation = arr.find(anno => anno._id === id);
-    this.selectedAnnotation.next(id);
+    this.selectedAnnotation$.next(id);
     if (!selectedAnnotation) return;
 
     const perspective = selectedAnnotation.body.content.relatedPerspective;
@@ -671,7 +646,7 @@ export class AnnotationService {
   }
 
   public setEditModeAnnotation(id: string) {
-    this.editModeAnnotation.next(id);
+    this.editModeAnnotation$.next(id);
   }
 
   public async shareAnnotation(annotation: IAnnotation) {
@@ -679,12 +654,14 @@ export class AnnotationService {
     dialogConfig.disableClose = true;
     dialogConfig.autoFocus = true;
 
-    if (!this.entity) {
+    const entity = await firstValueFrom(this.processing.entity$);
+
+    if (!entity) {
       throw new Error('Entity missing');
     }
 
     dialogConfig.data = {
-      entityId: this.entity._id,
+      entityId: entity._id,
     };
 
     const dialogRef = this.dialog.open(DialogShareAnnotationComponent, dialogConfig);
@@ -710,14 +687,17 @@ export class AnnotationService {
       });
   }
 
-  public createCopyOfAnnotation(
+  public async createCopyOfAnnotation(
     annotation: IAnnotation,
     collectionId: string,
     annotationLength: number,
-  ): any {
+  ) {
     const generatedId = this.backend.generateEntityId();
 
-    if (!this.entity) {
+    const entity = await firstValueFrom(this.processing.entity$);
+    const userdata = await firstValueFrom(this.userdata.userData$);
+
+    if (!entity) {
       throw new Error('Entity missing');
     }
 
@@ -732,13 +712,13 @@ export class AnnotationService {
       motivation: annotation.motivation,
       lastModifiedBy: {
         type: 'person',
-        name: this.userdata.userData ? this.userdata.userData.fullname : 'guest',
-        _id: this.userdata.userData ? this.userdata.userData._id : 'guest',
+        name: userdata ? userdata.fullname : 'guest',
+        _id: userdata ? userdata._id : 'guest',
       },
       body: annotation.body,
       target: {
         source: {
-          relatedEntity: this.entity._id,
+          relatedEntity: entity._id,
           relatedCompilation: collectionId,
         },
         selector: annotation.target.selector,

--- a/src/app/services/babylon/babylon.service.ts
+++ b/src/app/services/babylon/babylon.service.ts
@@ -72,7 +72,6 @@ export class BabylonService {
 
   private effects: PostProcess[] = [];
 
-  public mediaType = '';
   public videoContainer: IVideoContainer;
   public audioContainer: IAudioContainer;
   public imageContainer: IImageContainer;
@@ -105,8 +104,8 @@ export class BabylonService {
     }),
     setActiveCameraTarget: (targetVector: Vector3) =>
       setCameraTarget(this.getActiveCamera(), targetVector),
-    setUpActiveCamera: (maxSize: number) =>
-      setUpCamera(this.getActiveCamera(), maxSize, this.mediaType),
+    setUpActiveCamera: (maxSize: number, mediaType: string) =>
+      setUpCamera(this.getActiveCamera(), maxSize, mediaType),
     setCameraType: (type: 'ArcRotateCamera' | 'UniversalCamera') => {
       const cameras = this.scene.cameras;
       const currentType = this.cameraManager.cameraType$.getValue();
@@ -348,8 +347,6 @@ export class BabylonService {
     if (clearScene) {
       this.clearScene();
     }
-    // TODO: manage mediaType via Observable
-    this.mediaType = mediaType;
     switch (mediaType) {
       case 'audio':
         return loadAudio(rootUrl, this.scene, this.audioContainer, this.entityContainer).then(

--- a/src/app/services/babylon/babylon.service.ts
+++ b/src/app/services/babylon/babylon.service.ts
@@ -353,7 +353,7 @@ export class BabylonService {
       case 'entity':
       case 'model':
       default:
-        return load3DEntity(rootUrl, this.scene).then(result => {
+        return load3DEntity(rootUrl, this.scene, isDefault).then(result => {
           entity$.next(result);
           return result.meshes;
         });

--- a/src/app/services/babylon/container.interfaces.ts
+++ b/src/app/services/babylon/container.interfaces.ts
@@ -1,5 +1,5 @@
 import {
-  AbstractMesh,
+  Mesh,
   Analyser,
   AnimationGroup,
   IParticleSystem,
@@ -21,17 +21,17 @@ export interface IVideoContainer {
   video: HTMLVideoElement;
   currentTime: number;
   timeSlider: Slider;
-  plane?: AbstractMesh;
+  plane: Mesh;
 }
 
 export interface IImageContainer {
   image: Texture;
-  plane?: AbstractMesh;
+  plane: Mesh;
   material?: StandardMaterial;
 }
 
 export interface I3DEntityContainer {
-  meshes: AbstractMesh[];
+  meshes: Mesh[];
   particleSystems: IParticleSystem[];
   skeletons: Skeleton[];
   animationGroups: AnimationGroup[];

--- a/src/app/services/babylon/strategies/loading-strategies.ts
+++ b/src/app/services/babylon/strategies/loading-strategies.ts
@@ -4,15 +4,15 @@ import {
   Analyser,
   Engine,
   ExecuteCodeAction,
+  ISceneLoaderProgressEvent,
+  Material,
   Mesh,
   MeshBuilder,
+  PBRMaterial,
   Scene,
   SceneLoader,
-  ISceneLoaderProgressEvent,
-  PBRMaterial,
   Sound,
   StandardMaterial,
-  Material,
   Tags,
   Texture,
   Tools,
@@ -21,7 +21,6 @@ import {
 } from '@babylonjs/core';
 import { AdvancedDynamicTexture, Control, Slider, StackPanel, TextBlock } from '@babylonjs/gui';
 import '@babylonjs/loaders';
-
 import {
   I3DEntityContainer,
   IAudioContainer,
@@ -88,7 +87,7 @@ const patchMeshPBR = (mesh: AbstractMesh, scene: Scene) => {
   }
 };
 
-export const load3DEntity = (rootUrl: string, scene: Scene) => {
+export const load3DEntity = (rootUrl: string, scene: Scene, isDefault?: boolean) => {
   const rootFolder = Tools.GetFolderPath(rootUrl);
   const filename = Tools.GetFilename(rootUrl);
   const extension = filename.includes('.') ? `.${filename.split('.').slice(-1).pop()!}` : undefined;
@@ -102,16 +101,21 @@ export const load3DEntity = (rootUrl: string, scene: Scene) => {
     scene,
     updateLoadingUI(engine),
     extension,
-  )
-    .then(result => {
-      console.log(result);
-      result.meshes.forEach(mesh => patchMeshPBR(mesh, scene));
-      return result;
-    })
-    .catch(e => {
-      console.error(e);
-      engine.hideLoadingUI();
-    });
+  ).then(result => {
+    console.log(result);
+    if (isDefault) {
+      // Ignore environment lighting
+      result.meshes.forEach(mesh => {
+        if (!mesh.material) return;
+        const material = mesh.material as PBRMaterial;
+        material.environmentIntensity = 0;
+      });
+      // Disable Tone-Mapping
+      scene.imageProcessingConfiguration.toneMappingEnabled = false;
+    }
+    result.meshes.forEach(mesh => patchMeshPBR(mesh, scene));
+    return result as unknown as I3DEntityContainer;
+  });
 };
 
 const requestFile = (url: string) => {
@@ -120,13 +124,7 @@ const requestFile = (url: string) => {
     .catch(e => console.error(e));
 };
 
-export const loadImage = (
-  rootUrl: string,
-  scene: Scene,
-  imageContainer: IImageContainer,
-  isDefault?: boolean,
-) => {
-  const engine = scene.getEngine();
+export const loadImage = (rootUrl: string, scene: Scene, isDefault?: boolean) => {
   return new Promise<IImageContainer>((resolve, reject) => {
     const texture = new Texture(
       rootUrl,
@@ -160,7 +158,6 @@ export const loadImage = (
         }
 
         const newImageContainer: IImageContainer = {
-          ...imageContainer,
           image: texture,
           material: gndmat,
           plane: ground,
@@ -172,18 +169,12 @@ export const loadImage = (
         reject(err);
       },
     );
-  })
-    .then(image => {
-      return image;
-    })
-    .catch(e => {
-      engine.hideLoadingUI();
-      console.error(e);
-    });
+  }).then(image => {
+    return image;
+  });
 };
 
-export const loadVideo = (rootUrl: string, scene: Scene, videoContainer: IVideoContainer) => {
-  const engine = scene.getEngine();
+export const loadVideo = (rootUrl: string, scene: Scene) => {
   const filename = Tools.GetFilename(rootUrl);
 
   // TODO: Reject on videoTexture fails loading?
@@ -193,7 +184,6 @@ export const loadVideo = (rootUrl: string, scene: Scene, videoContainer: IVideoC
       const video = videoTexture.video;
       const { plane, timeSlider } = createVideoScene(videoTexture, texture, scene);
       const newContainer: IVideoContainer = {
-        ...videoContainer,
         video,
         currentTime: 0,
         timeSlider,
@@ -202,14 +192,9 @@ export const loadVideo = (rootUrl: string, scene: Scene, videoContainer: IVideoC
       resolve(newContainer);
       return newContainer;
     });
-  })
-    .then(resultContainer => {
-      return resultContainer;
-    })
-    .catch(e => {
-      console.error(e);
-      engine.hideLoadingUI();
-    });
+  }).then(resultContainer => {
+    return resultContainer;
+  });
 };
 
 const createVideoScene = (videoTexture: VideoTexture, texture: Texture, scene: Scene) => {
@@ -243,39 +228,27 @@ const createVideoScene = (videoTexture: VideoTexture, texture: Texture, scene: S
   return { plane, timeSlider };
 };
 
-export const loadAudio = (
-  rootUrl: string,
-  scene: Scene,
-  audioContainer: IAudioContainer,
-  cubeMeshes: I3DEntityContainer,
-) => {
-  const engine = scene.getEngine();
+export const loadAudio = (rootUrl: string, scene: Scene, meshes: Mesh[]) => {
   const filename = Tools.GetFilename(rootUrl);
-  return requestFile(rootUrl)
-    .then(async (arrayBuffer): Promise<IAudioContainer> => {
-      const audio = await new Promise<Sound>((resolve, _) => {
-        const sound = new Sound(`Audio: ${filename}`, arrayBuffer, scene, () => {
-          resolveSound();
-        });
-        const resolveSound = () => resolve(sound);
+  return requestFile(rootUrl).then(async (arrayBuffer): Promise<IAudioContainer> => {
+    const audio = await new Promise<Sound>((resolve, _) => {
+      const sound = new Sound(`Audio: ${filename}`, arrayBuffer, scene, () => {
+        resolveSound();
       });
-
-      const { timeSlider, analyser } = createAudioScene(audio, scene, cubeMeshes);
-      return {
-        ...audioContainer,
-        audio,
-        currentTime: 0,
-        timeSlider,
-        analyser,
-      };
-    })
-    .catch(e => {
-      console.error(e);
-      engine.hideLoadingUI();
+      const resolveSound = () => resolve(sound);
     });
+
+    const { timeSlider, analyser } = createAudioScene(audio, scene, meshes);
+    return {
+      audio,
+      currentTime: 0,
+      timeSlider,
+      analyser,
+    };
+  });
 };
 
-const createAudioScene = (audio: Sound, scene: Scene, cubeMeshes: I3DEntityContainer) => {
+const createAudioScene = (audio: Sound, scene: Scene, meshes: Mesh[]) => {
   // audio analyser
   const analyser = new Analyser(scene);
   // TODO: AudioEngine implements IAudioEngine
@@ -287,7 +260,7 @@ const createAudioScene = (audio: Sound, scene: Scene, cubeMeshes: I3DEntityConta
   const timeSlider = createMediaControls(30, 20, scene, undefined, audio);
 
   // Click on cube -> start/ stop sound
-  cubeMeshes.meshes.forEach(mesh => {
+  meshes.forEach(mesh => {
     Tags.AddTagsTo(mesh, 'audioCenter');
     mesh.isPickable = true;
     mesh.actionManager = new ActionManager(scene);

--- a/src/app/services/babylon/strategies/loading-strategies.ts
+++ b/src/app/services/babylon/strategies/loading-strategies.ts
@@ -252,25 +252,23 @@ export const loadAudio = (
   const engine = scene.getEngine();
   const filename = Tools.GetFilename(rootUrl);
   return requestFile(rootUrl)
-    .then(
-      async (arrayBuffer): Promise<IAudioContainer> => {
-        const audio = await new Promise<Sound>((resolve, _) => {
-          const sound = new Sound(`Audio: ${filename}`, arrayBuffer, scene, () => {
-            resolveSound();
-          });
-          const resolveSound = () => resolve(sound);
+    .then(async (arrayBuffer): Promise<IAudioContainer> => {
+      const audio = await new Promise<Sound>((resolve, _) => {
+        const sound = new Sound(`Audio: ${filename}`, arrayBuffer, scene, () => {
+          resolveSound();
         });
+        const resolveSound = () => resolve(sound);
+      });
 
-        const { timeSlider, analyser } = createAudioScene(audio, scene, cubeMeshes);
-        return {
-          ...audioContainer,
-          audio,
-          currentTime: 0,
-          timeSlider,
-          analyser,
-        };
-      },
-    )
+      const { timeSlider, analyser } = createAudioScene(audio, scene, cubeMeshes);
+      return {
+        ...audioContainer,
+        audio,
+        currentTime: 0,
+        timeSlider,
+        analyser,
+      };
+    })
     .catch(e => {
       console.error(e);
       engine.hideLoadingUI();
@@ -404,15 +402,13 @@ const createMediaControls = (
   return timeSlider;
 };
 
-const str_pad_left = (value: number, pad: string, length: number) => {
-  return (new Array(length + 1).join(pad) + value).slice(-length);
-};
+const padDigits = (value: number) => value.toString().padStart(2, '0');
 
 const getCurrentTime = (time: number): string => {
   const minutes = Math.floor(time / 60);
   const seconds = time - minutes * 60;
 
-  return `${str_pad_left(minutes, '0', 2)}:${str_pad_left(seconds, '0', 2)}`;
+  return `${padDigits(minutes)}:${padDigits(seconds)}`;
 };
 
 const secondsToHms = (sec: string | number) => {

--- a/src/app/services/entitysettings/entitysettings.service.ts
+++ b/src/app/services/entitysettings/entitysettings.service.ts
@@ -247,7 +247,7 @@ export class EntitySettingsService {
       );
     }
     const max = !isDefault ? (isInUpload && isModel ? diagonalLength * 2.5 : diagonalLength) : 87.5;
-    await this.babylon.cameraManager.setUpActiveCamera(max);
+    await this.babylon.cameraManager.setUpActiveCamera(max, mediaType!);
 
     if (isInUpload && mediaType !== 'audio') {
       const position = new Vector3(

--- a/src/app/services/light/light.service.ts
+++ b/src/app/services/light/light.service.ts
@@ -19,8 +19,8 @@ export class LightService {
 
   constructor(private babylon: BabylonService, private processing: ProcessingService) {
     this.scene = this.babylon.getScene();
-    this.processing.entitySettings$.subscribe(settings => {
-      this.entitySettings = settings;
+    this.processing.settings$.subscribe(({ localSettings }) => {
+      this.entitySettings = localSettings;
     });
   }
 

--- a/src/app/services/overlay/overlay.service.ts
+++ b/src/app/services/overlay/overlay.service.ts
@@ -5,38 +5,24 @@ import { BehaviorSubject } from 'rxjs';
   providedIn: 'root',
 })
 export class OverlayService {
-  private sidenavIsOpen = true;
-  private _mode = '';
-  private sidenavMode = new BehaviorSubject(this._mode);
-  public sidenavMode$ = this.sidenavMode.asObservable();
-
-  private sidenav = new BehaviorSubject(this.sidenavIsOpen);
-  public sidenav$ = this.sidenav.asObservable();
+  public sidenav$ = new BehaviorSubject({ mode: '', open: true });
 
   public toggleSidenav(mode: string, open?: boolean): boolean {
-    if (this._mode === mode) {
-      if (open !== undefined) {
-        this.sidenavIsOpen = open;
-      } else {
-        this.sidenavIsOpen = !this.sidenavIsOpen;
-      }
-      this.sidenav.next(this.sidenavIsOpen);
-      return this.sidenavIsOpen;
+    const sidenavState = this.sidenav$.getValue();
+
+    if (sidenavState.mode === mode) {
+      const shouldOpen = open !== undefined ? open : !sidenavState.open;
+      this.sidenav$.next({ ...sidenavState, open: shouldOpen });
+      return shouldOpen;
     }
 
-    setTimeout(
-      () => {
-        this.sidenavIsOpen = true;
-        this.sidenav.next(this.sidenavIsOpen);
-      },
-      this.sidenavIsOpen ? 300 : 0,
-    );
+    if (sidenavState.open) {
+      setTimeout(() => this.sidenav$.next({ ...sidenavState, open: true }), 300);
+    } else {
+      this.sidenav$.next({ ...sidenavState, open: true });
+    }
 
-    this._mode = mode;
-    this.sidenavMode.next(this._mode);
-
-    this.sidenavIsOpen = false;
-    this.sidenav.next(this.sidenavIsOpen);
+    this.sidenav$.next({ mode, open: false });
     return true;
   }
 }

--- a/src/app/services/overlay/overlay.service.ts
+++ b/src/app/services/overlay/overlay.service.ts
@@ -7,22 +7,15 @@ import { BehaviorSubject } from 'rxjs';
 export class OverlayService {
   public sidenav$ = new BehaviorSubject({ mode: '', open: true });
 
-  public toggleSidenav(mode: string, open?: boolean): boolean {
+  public toggleSidenav(mode: string, open?: boolean) {
     const sidenavState = this.sidenav$.getValue();
 
     if (sidenavState.mode === mode) {
       const shouldOpen = open !== undefined ? open : !sidenavState.open;
-      this.sidenav$.next({ ...sidenavState, open: shouldOpen });
-      return shouldOpen;
+      return this.sidenav$.next({ mode, open: shouldOpen });
     }
 
-    if (sidenavState.open) {
-      setTimeout(() => this.sidenav$.next({ ...sidenavState, open: true }), 300);
-    } else {
-      this.sidenav$.next({ ...sidenavState, open: true });
-    }
-
+    setTimeout(() => this.sidenav$.next({ mode, open: true }), sidenavState.open ? 300 : 0);
     this.sidenav$.next({ mode, open: false });
-    return true;
   }
 }

--- a/src/app/services/pouch/pouch.service.ts
+++ b/src/app/services/pouch/pouch.service.ts
@@ -6,7 +6,7 @@ import { IAnnotation } from 'src/common';
 @Injectable({
   providedIn: 'root',
 })
-export class DataService {
+export class PouchService {
   public pouchdb: PouchDB.Database = new PouchDB('annotationdb');
 
   public fetch() {

--- a/src/app/services/processing/processing.service.ts
+++ b/src/app/services/processing/processing.service.ts
@@ -508,18 +508,16 @@ export class ProcessingService {
   }
 
   private async fetchRestrictedEntityData(entity: IEntity) {
-    const isOwner = this.userdata.doesUserOwn(entity);
-    const isUserWhitelisted = this.userdata.isUserWhitelistedFor(entity);
     this.userdata
       .userAuthentication(true)
       .then(auth => {
         // Check for user authentication
         if (!auth) return false;
         // Check for ownership
-        if (!isOwner) {
+        if (!this.userdata.doesUserOwn(entity)) {
           // Check for whitelist
           if (!entity.whitelist.enabled) return false;
-          if (!isUserWhitelisted) return false;
+          if (!this.userdata.isUserWhitelistedFor(entity)) return false;
         }
         return true;
       })

--- a/src/app/services/processing/processing.service.ts
+++ b/src/app/services/processing/processing.service.ts
@@ -564,15 +564,16 @@ export class ProcessingService {
     // cases: entity, image, audio, video, text
     const path: string = newEntity.externalFile ?? newEntity.processed[this.entityQuality];
     const isAudio = mediaType === 'audio';
-    const url = isAudio
-      ? 'assets/models/kompakkt.babylon'
-      : path.includes('http') || path.includes('https')
-      ? path
-      : `${baseURL}${path}`;
+    const url = path.includes('http') || path.includes('https') ? path : `${baseURL}${path}`;
     const isDefault = newEntity._id === 'default';
 
     this.babylon
-      .loadEntity(true, url, isAudio ? 'model' : mediaType, isDefault)
+      .loadEntity(
+        true,
+        isAudio ? 'assets/models/kompakkt.babylon' : url,
+        isAudio ? 'model' : mediaType,
+        isDefault,
+      )
       .then(meshes => {
         if (isAudio) return this.babylon.loadEntity(false, url, mediaType);
         return meshes;

--- a/src/app/services/userdata/userdata.service.ts
+++ b/src/app/services/userdata/userdata.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { BehaviorSubject, combineLatestWith, firstValueFrom, map } from 'rxjs';
 import {
   IAnnotation,
   ICompilation,
@@ -13,101 +14,128 @@ import {
 
 import { LoginComponent } from '../../components/dialogs/dialog-login/login.component';
 import { BackendService } from '../backend/backend.service';
+import { ProcessingService } from '../processing/processing.service';
+
+const getWhitelistedPersons = (element: IEntity | ICompilation) => {
+  return (
+    element.whitelist.groups
+      // Flatten group members and owners
+      .map(group => group.members.concat(...group.owners))
+      .reduce((acc, val) => acc.concat(val), [] as IStrippedUserData[])
+      // Combine with whitelisted persons
+      .concat(...element.whitelist.persons)
+  );
+};
+
+const isUserOwned = (
+  element: IEntity | ICompilation | null,
+  userdata: IUserData | undefined,
+  elementType: 'entity' | 'compilation',
+) => {
+  if (!element || !userdata) return false;
+  const userElements = userdata.data?.[elementType];
+  return userElements?.some((other: IEntity | ICompilation) => other._id === element._id);
+};
+
+const isUserWhitelisted = (
+  element: IEntity | ICompilation | null,
+  userdata: IUserData | undefined,
+) => {
+  if (!element || !userdata) return false;
+  const persons = getWhitelistedPersons(element);
+  return !!persons.find(person => person._id === userdata._id);
+};
+
+export type LoginData = { username: string; password: string };
 
 @Injectable({
   providedIn: 'root',
 })
 export class UserdataService {
-  public loginRequired = false;
-  public authenticatedUser = false;
-  public loginData = {
-    username: '',
-    password: '',
-    isCached: false,
-  };
-  public userData: IUserData | undefined = undefined;
-  public guestUserData: IStrippedUserData | undefined;
+  public loginRequired$ = new BehaviorSubject(false);
+  public loginData$ = new BehaviorSubject<LoginData | undefined>(undefined);
+  public userData$ = new BehaviorSubject<IUserData | undefined>(undefined);
+  public isAuthenticated$ = this.userData$.pipe(map(userdata => !!userdata?._id));
 
-  public userOwnsEntity = false;
-  public userOwnsCompilation = false;
-  public userWhitlistedEntity = false;
-  public userWhitlistedCompilation = false;
+  public userOwnsEntity$ = this.processing.entity$.pipe(
+    combineLatestWith(this.userData$),
+    map(([entity, userdata]) => isEntity(entity) && isUserOwned(entity, userdata, 'entity')),
+  );
 
-  constructor(private backend: BackendService, private dialog: MatDialog) {}
+  public userOwnsCompilation$ = this.processing.compilation$.pipe(
+    combineLatestWith(this.userData$),
+    map(
+      ([compilation, userdata]) =>
+        isCompilation(compilation) && isUserOwned(compilation, userdata, 'compilation'),
+    ),
+  );
 
-  public userAuthentication(loginRequired: boolean): Promise<boolean> {
-    this.loginRequired = loginRequired;
+  public isUserWhitelistedInEntity$ = this.processing.entity$.pipe(
+    combineLatestWith(this.userData$),
+    map(([entity, userdata]) => isEntity(entity) && isUserWhitelisted(entity, userdata)),
+  );
 
-    return new Promise<boolean>((resolve, _) => {
-      if (this.authenticatedUser && this.userData) resolve(true);
-      this.backend
-        .isAuthorized()
-        .then(result => {
-          this.setUserData(result);
-          this.authenticatedUser = true;
-          resolve(true);
-        })
-        .catch(e => {
-          if (loginRequired) {
-            this.attemptLogin().then(authorized => {
-              resolve(authorized);
-            });
-          } else {
-            // Server might not be reachable, skip login
-            console.error(e);
-            this.clearUserData();
-            resolve(false);
-          }
-        });
-    });
+  public isUserWhitelistedInCompilation$ = this.processing.compilation$.pipe(
+    combineLatestWith(this.userData$),
+    map(
+      ([compilation, userdata]) =>
+        isCompilation(compilation) && isUserWhitelisted(compilation, userdata),
+    ),
+  );
+
+  constructor(
+    private backend: BackendService,
+    private dialog: MatDialog,
+    private processing: ProcessingService,
+  ) {}
+
+  public async userAuthentication(loginRequired: boolean): Promise<boolean> {
+    this.loginRequired$.next(loginRequired);
+    const isAuthenticated = await firstValueFrom(this.isAuthenticated$);
+    if (isAuthenticated) return true;
+
+    return this.backend
+      .isAuthorized()
+      .then(result => {
+        this.userData$.next(result);
+        return true;
+      })
+      .catch(async e => {
+        if (loginRequired) {
+          return await this.attemptLogin();
+        } else {
+          // Server might not be reachable, skip login
+          console.error(e);
+          return false;
+        }
+      });
   }
 
   private async attemptLogin(): Promise<boolean> {
-    return new Promise<boolean>((resolve, _) => {
-      if (this.loginData.isCached) {
-        this.backend
-          .login(this.loginData.username, this.loginData.password)
-          .then(result => {
-            this.setUserData(result);
-            this.authenticatedUser = true;
-            resolve(true);
-          })
-          .catch(() => {
-            this.openLoginDialog().then(loggedIn => {
-              resolve(loggedIn);
-            });
+    const loginData = this.loginData$.getValue();
 
-            /*console.error(err);
-            this.clearUserData();
-            reject(false);*/
-          });
-      } else {
-        this.openLoginDialog().then(loggedIn => {
-          resolve(loggedIn);
-        });
-      }
-    });
+    if (loginData) {
+      return this.backend
+        .login(loginData.username, loginData.password)
+        .then(result => {
+          this.userData$.next(result);
+          return true;
+        })
+        .catch(() => this.openLoginDialog());
+    }
+
+    return this.openLoginDialog();
   }
 
-  public openLoginDialog(): Promise<boolean> {
-    return new Promise<boolean>(resolve => {
-      const dialogRef = this.dialog.open(LoginComponent);
-      dialogRef.afterClosed().subscribe(result => {
-        if (result !== false) {
-          const data = result.data;
-          this.setUserData(data.userData);
-          this.authenticatedUser = true;
-          this.loginData = {
-            username: data.username,
-            password: data.password,
-            isCached: true,
-          };
-          resolve(true);
-        } else {
-          resolve(false);
-        }
-      });
-    });
+  public async openLoginDialog(): Promise<boolean> {
+    const dialogRef = this.dialog.open(LoginComponent);
+    const result = await firstValueFrom(dialogRef.afterClosed());
+    if (!result || result === false) return false;
+
+    const { username, password, userData } = result.data;
+    this.userData$.next(userData);
+    this.loginData$.next({ username, password });
+    return true;
   }
 
   public logout() {
@@ -115,121 +143,15 @@ export class UserdataService {
       .logout()
       .then(() => {})
       .catch(err => console.error(err));
-    this.clearUserData();
-  }
-
-  private clearUserData() {
-    this.authenticatedUser = false;
-    this.loginData = {
-      username: '',
-      password: '',
-      isCached: false,
-    };
-    this.userData = undefined;
-    this.guestUserData = undefined;
-    this.userOwnsEntity = false;
-    this.userOwnsCompilation = false;
-    this.userWhitlistedEntity = false;
-    this.userWhitlistedCompilation = false;
-  }
-
-  private setUserData(userData: IUserData) {
-    if (this.guestUserData) this.guestUserData = undefined;
-    this.userData = userData;
-  }
-
-  public checkOwnerState(element: ICompilation | IEntity | undefined): boolean {
-    if (!element) {
-      return false;
-    }
-    if (!this.userData?.data || (!isEntity(element) && !isCompilation(element))) {
-      this.userOwnsEntity = false;
-      this.userOwnsCompilation = false;
-      return false;
-    }
-    const id = element._id;
-
-    if (isCompilation(element)) {
-      this.userOwnsCompilation = JSON.stringify(this.userData?.data?.compilation).includes(
-        element._id.toString(),
-      );
-      if (this.userOwnsCompilation) {
-        return this.userOwnsCompilation;
-      }
-      if (this.userData.data.compilation) {
-        this.userOwnsCompilation =
-          this.userData.data.compilation.find(
-            (_compilation: ICompilation) => _compilation._id === id,
-          ) !== undefined;
-      }
-      return this.userOwnsCompilation;
-    }
-
-    if (isEntity(element)) {
-      this.userOwnsEntity = JSON.stringify(this.userData?.data?.entity).includes(
-        element._id.toString(),
-      );
-      if (this.userOwnsEntity) {
-        return this.userOwnsEntity;
-      }
-      if (this.userData.data.entity) {
-        this.userOwnsEntity =
-          this.userData.data.entity.find((_entity: IEntity) => _entity._id === id) !== undefined;
-      } else {
-        this.userOwnsEntity = false;
-      }
-      return this.userOwnsEntity;
-    }
-    return false;
-  }
-
-  public isUserWhitelisted(element: ICompilation | IEntity | undefined): boolean {
-    if (!element) {
-      return false;
-    }
-    if (!this.userData?.data) {
-      this.userWhitlistedEntity = false;
-      this.userWhitlistedCompilation = false;
-      return false;
-    }
-    const id = this.userData._id;
-
-    const persons = element.whitelist.groups
-      // Flatten group members and owners
-      .map(group => group.members.concat(...group.owners))
-      .reduce((acc, val) => acc.concat(val), [] as IStrippedUserData[])
-      // Combine with whitelisted persons
-      .concat(...element.whitelist.persons);
-
-    const whitelistContainsUser = persons.find(person => person._id === id) !== undefined;
-
-    if (isEntity(element)) {
-      this.userWhitlistedEntity = whitelistContainsUser;
-    }
-    // tslint:disable-next-line:max-line-length
-    if (isCompilation(element)) {
-      this.userWhitlistedCompilation = whitelistContainsUser;
-    }
-
-    return whitelistContainsUser;
+    this.userData$.next(undefined);
+    this.loginData$.next(undefined);
   }
 
   public isAnnotationOwner(annotation: IAnnotation): boolean {
-    if (this.userData?.data?.annotation) {
-      const result = this.userData.data.annotation.find(
-        anno => isAnnotation(anno) && anno._id === annotation._id,
-      );
-      if (result) return true;
-    }
-    return annotation.creator._id === this.userData?._id ?? false;
-  }
+    const userData = this.userData$.getValue();
+    const annotations = userData?.data?.annotation;
 
-  public createTemporalUserData() {
-    if (this.userData) return;
-    this.guestUserData = {
-      fullname: 'guest',
-      username: 'guest',
-      _id: this.backend.generateEntityId(),
-    };
+    if (annotation.creator._id === userData?._id) return true;
+    return annotations?.some(other => isAnnotation(other) && other._id === annotation._id) ?? false;
   }
 }


### PR DESCRIPTION
### What?

This PR is an attempt to clean up big services, mainly the `ProcessingService` and switch their most accessed variables to RxJS `Subject`s & *Observable`s.

This includes:
- renaming things for humans, so new contributors might have an easier time understanding what a variable is needed for.
- removing duplicate variables from components & services that used to just copy the current value from `ProcessingService`, which would in turn never know if something gets updated elsewhere
- moving data back to the services
- combining variables that share the same context to objects
- getting rid of side effects

Ideally, this should work as a drop-in replacement.

### Why was this done?

Even as one of the core developers, it was not always easy to understand or debug how the data flows from services to components in the Viewer, or how components modified service data. This slows down feature development and blocks-off potential new developers.