### PR TITLE
Fix: Loading screen visibility

### DIFF
--- a/src/app/services/babylon/loadingscreen.ts
+++ b/src/app/services/babylon/loadingscreen.ts
@@ -11,11 +11,11 @@ export class LoadingScreenService {
   public isLoading = false;
 
   public show() {
-    if (!this.isLoading) setTimeout(() => this.updateOpacity('1'), 500);
+    this.updateOpacity('1');
   }
 
   public hide() {
-    if (this.isLoading) this.updateOpacity('0');
+    this.updateOpacity('0');
   }
 
   public updateOpacity(newOpacity: string): void {

--- a/src/app/services/babylon/strategies/loading-strategies.ts
+++ b/src/app/services/babylon/strategies/loading-strategies.ts
@@ -87,7 +87,7 @@ const patchMeshPBR = (mesh: AbstractMesh, scene: Scene) => {
   }
 };
 
-export const load3DEntity = (rootUrl: string, scene: Scene, isDefault?: boolean) => {
+export const load3DEntity = async (rootUrl: string, scene: Scene, isDefault?: boolean) => {
   const rootFolder = Tools.GetFolderPath(rootUrl);
   const filename = Tools.GetFilename(rootUrl);
   const extension = filename.includes('.') ? `.${filename.split('.').slice(-1).pop()!}` : undefined;


### PR DESCRIPTION
The loading screen currently does not always disappear when it's supposed to, even when the scene content is loaded.

This PR is an attempt to fix this issue.