### PR TITLE
Fix: Loading screen does not always disappear

### DIFF
--- a/src/app/services/processing/processing.service.ts
+++ b/src/app/services/processing/processing.service.ts
@@ -394,6 +394,9 @@ export class ProcessingService {
         this.showSidenav$.next(!!overlay);
         this.overlay.toggleSidenav(overlay, !!overlay);
         this.bootstrapped$.next(true);
+      })
+      .finally(() => {
+        this.loadingScreen.hide();
       });
   }
 


### PR DESCRIPTION
This is a simple fix to make sure the loading screen is hidden after the Promise of loading a model resolves.