### PR TITLE
Introduce PostMessageService to handle communication between Viewer and parent windows

### DIFF
--- a/src/app/services/post-message/post-message.service.ts
+++ b/src/app/services/post-message/post-message.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { fromEvent } from 'rxjs';
+import { IEntitySettings } from '~common/interfaces';
+
+type Message = { type: string; data: unknown; settings?: IEntitySettings };
+const isMessage = (message: any): message is Message => {
+  return (
+    message.type &&
+    message.data &&
+    typeof message.data === 'object' &&
+    typeof message.type === 'string'
+  );
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PostMessageService {
+  constructor() {
+    fromEvent(window, 'message').subscribe(event => {
+      if (event instanceof MessageEvent) this.handleMessage(event);
+    });
+  }
+
+  get hasParent() {
+    return !!window.top;
+  }
+  public sendToParent(message: Message) {
+    if (!this.hasParent) return;
+    window.top?.postMessage(message, '*');
+  }
+
+  private handleMessage(event: MessageEvent) {
+    const message = event.data;
+    if (!isMessage(message)) return;
+    console.log('Got message', message);
+  }
+}


### PR DESCRIPTION
This PR adds a new service, `PostMessageService`, which handles communication between the Viewer and `window.top`, when used in an iframe.

The decision to add this was made, since communication to and from the Viewer as an iframe will be a larger requirement when embedding the Viewer in other contexts than our own Repo.