### PR TITLE
Fix: Build error for i18n aria-labels and missing translateItems

### DIFF
--- a/src/app/components/dialogs/dialog-annotation-editor/dialog-annotation-editor.component.html
+++ b/src/app/components/dialogs/dialog-annotation-editor/dialog-annotation-editor.component.html
@@ -31,9 +31,9 @@
     <mat-icon>{{ labelMode }}</mat-icon>
   </button>
   <button mat-button [mat-dialog-close]="data">
-    <mat-icon aria-label="{{ 'Save' | translate }}">save</mat-icon>
+    <mat-icon [attr.aria-label]="'Save' | translate">save</mat-icon>
   </button>
   <button mat-button (click)="cancel()">
-    <mat-icon aria-label="{{ 'Cancel' | translate }}">cancel</mat-icon>
+    <mat-icon [attr.aria-label]="'Cancel' | translate">cancel</mat-icon>
   </button>
 </div>

--- a/src/app/components/dialogs/dialog-invite-broadcasting/dialog-invite-broadcasting.component.html
+++ b/src/app/components/dialogs/dialog-invite-broadcasting/dialog-invite-broadcasting.component.html
@@ -22,7 +22,7 @@
       matTooltip="{{ 'click to copy' | translate }}"
       matTooltipPosition="above"
     >
-      <mat-icon aria-label="{{ 'Copy from Textbox' | translate }}">file_copy</mat-icon>
+      <mat-icon [attr.aria-label]="'Copy from Textbox' | translate">file_copy</mat-icon>
     </button>
     <mat-dialog-actions align="end">
       <button mat-button [mat-dialog-close]="true">{{ 'Close' | translate }}</button>

--- a/src/app/components/entity-feature-annotations/annotation-media-browser/media-browser.component.html
+++ b/src/app/components/entity-feature-annotations/annotation-media-browser/media-browser.component.html
@@ -8,7 +8,7 @@
       type="mat-icon-button"
       class="btn-add-medium"
     >
-      <mat-icon aria-label="{{ 'Add External Image' | translate }}">image</mat-icon>
+      <mat-icon [attr.aria-label]="'Add External Image' | translate">image</mat-icon>
     </button>
     <button
       *ngIf="compilation$ | async"
@@ -19,7 +19,7 @@
       type="mat-icon-button"
       class="btn-add-medium"
     >
-      <mat-icon aria-label="{{ 'Add Entity From Collection' | translate }}">folder_open</mat-icon>
+      <mat-icon [attr.aria-label]="'Add Entity From Collection' | translate">folder_open</mat-icon>
     </button>
   </div>
 
@@ -47,7 +47,7 @@
       matTooltipPosition="above"
       type="button"
     >
-      <mat-icon aria-label="{{ 'Add Image' | translate }}">add</mat-icon>
+      <mat-icon [attr.aria-label]="'Add Image' | translate">add</mat-icon>
       {{ 'Add Image' | translate }}
     </button>
   </div>

--- a/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
+++ b/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
@@ -22,7 +22,7 @@
       </mat-card-title>
 
       <mat-card-subtitle>
-        {{ annotation.validated ? translateItems[4] : translateItems[5] }}
+        {{ (annotation.validated ? 'validated' : 'not validated') | translate }}
       </mat-card-subtitle>
     </mat-card-header>
 
@@ -64,7 +64,7 @@
           type="button"
           class="perspective"
         >
-          <mat-icon aria-label="{{ 'Select Perspective' | translate }}">camera</mat-icon>
+          <mat-icon [attr.aria-label]="'Select Perspective' | translate">camera</mat-icon>
           {{ 'Select Perspective' | translate }}
         </button>
       </ng-container>
@@ -79,7 +79,7 @@
 
     <mat-card-actions>
       <mat-slide-toggle [checked]="showAnnotation$ | async" (change)="toggleVisibility()">
-        {{ (showAnnotation$ | async) ? translateItems[3] : translateItems[2] }}
+        {{ ((showAnnotation$ | async) ? "Hide" : "Show") | translate }}
       </mat-slide-toggle>
 
       <ng-container
@@ -88,12 +88,12 @@
         <button
           mat-icon-button
           (click)="toggleEditViewMode()"
-          [matTooltip]="(isEditMode$ | async) ? translateItems[0] : translateItems[1]"
+          [matTooltip]="((isEditMode$ | async) ? 'Save annotation' : 'Edit annotation') | translate"
           matTooltipPosition="above"
           type="button"
         >
           <mat-icon
-            [attr.aria-label]="(isEditMode$ | async) ? translateItems[0] : translateItems[1]"
+            [attr.aria-label]="((isEditMode$ | async) ? 'Save annotation' : 'Edit annotation') | translate"
           >
             {{ (isEditMode$ | async) ? 'save' : 'edit' }}
           </mat-icon>
@@ -106,7 +106,7 @@
           matTooltipPosition="above"
           type="button"
         >
-          <mat-icon aria-label="{{ 'Fullscreen' | translate }}">select_all</mat-icon>
+          <mat-icon [attr.aria-label]="'Fullscreen' | translate">select_all</mat-icon>
         </button>
 
         <button
@@ -116,7 +116,7 @@
           matTooltipPosition="above"
           type="button"
         >
-          <mat-icon aria-label="{{ 'Delete' | translate }}">delete</mat-icon>
+          <mat-icon [attr.aria-label]="'Delete' | translate">delete</mat-icon>
         </button>
       </ng-container>
 
@@ -128,7 +128,7 @@
         matTooltipPosition="above"
         type="button"
       >
-        <mat-icon aria-label="{{ 'Copy to collection' | translate }}">file_copy</mat-icon>
+        <mat-icon [attr.aria-label]="'Copy to collection' | translate">file_copy</mat-icon>
       </button>
     </mat-card-actions>
   </form>

--- a/src/app/components/entity-feature-annotations/annotation/annotation.component.html
+++ b/src/app/components/entity-feature-annotations/annotation/annotation.component.html
@@ -27,7 +27,7 @@
         </mat-card-title>
 
         <button id="closeButton" mat-icon-button (click)="closeAnnotation()" type="button">
-          <mat-icon aria-label="{{ 'Close' | translate }}">cancel</mat-icon>
+          <mat-icon [attr.aria-label]="'Close' | translate">cancel</mat-icon>
         </button>
       </mat-card-header>
 
@@ -63,7 +63,7 @@
           matTooltipPosition="above"
           type="button"
         >
-          <mat-icon aria-label="{{ 'Fullscreen' | translate }}">select_all</mat-icon>
+          <mat-icon [attr.aria-label]="'Fullscreen' | translate">select_all</mat-icon>
         </button>
 
         <button
@@ -87,7 +87,7 @@
           matTooltipPosition="above"
           type="button"
         >
-          <mat-icon aria-label="{{ 'Delete' | translate }}">delete</mat-icon>
+          <mat-icon [attr.aria-label]="'Delete' | translate">delete</mat-icon>
         </button>
       </mat-card-actions>
     </form>

--- a/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.html
+++ b/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.html
@@ -41,7 +41,7 @@
     matTooltipPosition="below"
     (click)="exportAnnotations()"
   >
-    <mat-icon aria-label="{{ 'Export Annotations to JSON' | translate }}">save</mat-icon>
+    <mat-icon [attr.aria-label]="'Export Annotations to JSON' | translate">save</mat-icon>
   </button>
   <!--app-broadcast [style.visibility]="isBroadcastingAllowed ? 'visible' : 'hidden'"></app-broadcast-->
 </div>

--- a/src/app/components/entity-feature-annotations/annotationwalkthrough/annotationwalkthrough.component.html
+++ b/src/app/components/entity-feature-annotations/annotationwalkthrough/annotationwalkthrough.component.html
@@ -6,7 +6,7 @@
     matTooltip="{{ 'Back' | translate }}"
     matTooltipPosition="above"
   >
-    <mat-icon aria-label="{{ 'Back' | translate }}">keyboard_arrow_left</mat-icon>
+    <mat-icon [attr.aria-label]="'Back' | translate">keyboard_arrow_left</mat-icon>
   </button>
 
   <div id="walktertitle">{{ title$ | async }}</div>
@@ -18,6 +18,6 @@
     matTooltip="{{ 'Next' | translate }}"
     matTooltipPosition="above"
   >
-    <mat-icon aria-label="{{ 'Save Scene' | translate }}">keyboard_arrow_right</mat-icon>
+    <mat-icon [attr.aria-label]="'Save Scene' | translate">keyboard_arrow_right</mat-icon>
   </button>
 </div>

--- a/src/app/components/entity-feature-settings/entity-feature-settings-mesh/entity-feature-settings-mesh.component.html
+++ b/src/app/components/entity-feature-settings/entity-feature-settings-mesh/entity-feature-settings-mesh.component.html
@@ -201,7 +201,7 @@
       matTooltipPosition="above"
       type="button"
     >
-      <mat-icon aria-label="{{ 'Rotate -90°' | translate }}">undo</mat-icon>
+      <mat-icon [attr.aria-label]="'Rotate -90°' | translate">undo</mat-icon>
     </button>
     <mat-form-field>
       <input
@@ -222,7 +222,7 @@
       matTooltipPosition="above"
       type="button"
     >
-      <mat-icon aria-label="{{ 'Rotate 90°' | translate }}">redo</mat-icon>
+      <mat-icon [attr.aria-label]="'Rotate 90°' | translate">redo</mat-icon>
     </button>
     <h5>Y</h5>
     <button
@@ -232,7 +232,7 @@
       matTooltipPosition="above"
       type="button"
     >
-      <mat-icon aria-label="{{ 'Rotate -90°' | translate }}">undo</mat-icon>
+      <mat-icon [attr.aria-label]="'Rotate -90°' | translate">undo</mat-icon>
     </button>
     <mat-form-field>
       <input
@@ -253,7 +253,7 @@
       matTooltipPosition="above"
       type="button"
     >
-      <mat-icon aria-label="{{ 'Rotate 90°' | translate }}">redo</mat-icon>
+      <mat-icon [attr.aria-label]="'Rotate 90°' | translate">redo</mat-icon>
     </button>
     <h5>Z</h5>
     <button
@@ -263,7 +263,7 @@
       matTooltipPosition="above"
       type="button"
     >
-      <mat-icon aria-label="{{ 'Rotate -90°' | translate }}">undo</mat-icon>
+      <mat-icon [attr.aria-label]="'Rotate -90°' | translate">undo</mat-icon>
     </button>
     <mat-form-field>
       <input
@@ -284,7 +284,7 @@
       matTooltipPosition="above"
       type="button"
     >
-      <mat-icon aria-label="{{ 'Rotate 90°' | translate }}">redo</mat-icon>
+      <mat-icon [attr.aria-label]="'Rotate 90°' | translate">redo</mat-icon>
     </button>
   </div>
 </ng-container>

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -109,7 +109,7 @@
     matTooltip="{{ ( fullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen' ) | translate }}"
     matTooltipPosition="above"
   >
-    <mat-icon aria-label="{{ 'Exit fullscreen mode' | translate }}">{{
+    <mat-icon [attr.aria-label]="'Exit fullscreen mode' | translate">{{
       fullscreen ? 'fullscreen_exit' : 'fullscreen'
     }}</mat-icon>
   </button>

--- a/src/app/components/sidenav-menu/sidenav-menu.component.html
+++ b/src/app/components/sidenav-menu/sidenav-menu.component.html
@@ -6,8 +6,8 @@
       [matTooltip]="( isOpen && isAnnotation ? 'Close' : 'Annotation' ) | translate"
       matTooltipPosition="right"
     >
-      <mat-icon aria-label="{{ 'Toggle Annotation' | translate }}">place</mat-icon>
-      <mat-icon class="arrow" aria-label="{{ 'Toggle Annotation' | translate }}">
+      <mat-icon [attr.aria-label]="'Toggle Annotation' | translate">place</mat-icon>
+      <mat-icon class="arrow" [attr.aria-label]="'Toggle Annotation' | translate">
         {{ isOpen && isAnnotation ? 'arrow_left' : 'arrow_right' }}
       </mat-icon>
     </button>
@@ -19,8 +19,8 @@
       [matTooltip]="( isOpen && isSettings ? 'Close' : 'Settings' ) | translate"
       matTooltipPosition="right"
     >
-      <mat-icon aria-label="{{ 'Toggle Settings' | translate }}">settings</mat-icon>
-      <mat-icon class="arrow" aria-label="{{ 'Toggle Settings' | translate }}">
+      <mat-icon [attr.aria-label]="'Toggle Settings' | translate">settings</mat-icon>
+      <mat-icon class="arrow" [attr.aria-label]="'Toggle Settings' | translate">
         {{ isOpen && isSettings ? 'arrow_left' : 'arrow_right' }}
       </mat-icon>
     </button>
@@ -32,8 +32,8 @@
       [matTooltip]="( isOpen && isCompilationBrowser ? 'Close' : 'Browse in Collection' ) | translate"
       matTooltipPosition="right"
     >
-      <mat-icon aria-label="{{ 'Toggle Collection Browser' | translate }}">folder_open</mat-icon>
-      <mat-icon class="arrow" aria-label="{{ 'Toggle Collection Browser' | translate }}">
+      <mat-icon [attr.aria-label]="'Toggle Collection Browser' | translate">folder_open</mat-icon>
+      <mat-icon class="arrow" [attr.aria-label]="'Toggle Collection Browser' | translate">
         {{ isOpen && isCompilationBrowser ? 'arrow_left' : 'arrow_right' }}
       </mat-icon>
     </button>


### PR DESCRIPTION
The merge of the i18n features introduced build errors regarding translation of some aria-labels and calls to the removed translateItems variable in a component.

This PR resolves these issues, allowing for the viewer to be built again.