### PR TITLE
Fix: Decode "endpoint" and "resource" parameters in standalone loading.

### DIFF
--- a/src/app/helpers/base64-helper.ts
+++ b/src/app/helpers/base64-helper.ts
@@ -1,4 +1,4 @@
-const decodeURIUntilStable = (str: string, max = 3) => {
+export const decodeURIUntilStable = (str: string, max = 3) => {
   const initial = str;
   let decoded = decodeURIComponent(str);
   let counter = 0;
@@ -10,29 +10,28 @@ const decodeURIUntilStable = (str: string, max = 3) => {
 };
 
 export const encodeBase64 = (str: string): string | undefined => {
-    try {
-        return btoa(encodeURIComponent(str.trim()));
-    } catch (error) {
-        return undefined;
-    }
+  try {
+    return btoa(encodeURIComponent(str.trim()));
+  } catch (error) {
+    return undefined;
+  }
 };
 
 export const decodeBase64 = (str: string) => {
-    try {
-        return atob(decodeURIUntilStable(str.trim()));
-    } catch (error) {
-        return undefined;
-    }
+  try {
+    return atob(decodeURIUntilStable(str.trim()));
+  } catch (error) {
+    return undefined;
+  }
 };
 
 export const isBase64 = (str: string) => {
-    if (str === '' || str.trim() === '') {
-        return false;
-    }
-    try {
-        return atob(decodeURIUntilStable(str.trim()));
-    } catch (error) {
-        return false;
-    }
+  if (str === '' || str.trim() === '') {
+    return false;
+  }
+  try {
+    return atob(decodeURIUntilStable(str.trim()));
+  } catch (error) {
+    return false;
+  }
 };
-

--- a/src/app/services/processing/processing.service.ts
+++ b/src/app/services/processing/processing.service.ts
@@ -24,7 +24,7 @@ import {
 import { environment } from '../../../environments/environment';
 // tslint:disable-next-line:max-line-length
 import { DialogPasswordComponent } from '../../components/dialogs/dialog-password/dialog-password.component';
-import { decodeBase64, isBase64 } from '../../helpers';
+import { decodeBase64, decodeURIUntilStable, isBase64 } from '../../helpers';
 import { convertIIIFAnnotation, IIIFData, isIIIFData } from '../../helpers/iiif-data-helper';
 import { BabylonService } from '../babylon/babylon.service';
 import { LoadingScreenService } from '../babylon/loadingscreen';
@@ -354,24 +354,27 @@ export class ProcessingService {
     console.log('loadStandaloneEntity', entries);
 
     const url = ((): string | undefined => {
-      if (!entries.endpoint && !entries.resource) {
-        return undefined;
-      }
+      const { endpoint, resource } = entries;
       // If only endpoint or resource is set, use as is
-      if (!entries.endpoint && entries.resource) {
-        if (isBase64(entries.resource)) {
-          return decodeBase64(entries.resource);
+      if (!endpoint && resource) {
+        if (isBase64(resource)) {
+          return decodeBase64(resource);
         }
-        return entries.resource;
+        return resource;
       }
-      if (entries.endpoint && !entries.resource) {
-        if (isBase64(entries.endpoint)) {
-          return decodeBase64(entries.endpoint);
+      if (endpoint && !resource) {
+        if (isBase64(endpoint)) {
+          return decodeBase64(endpoint);
         }
-        return entries.endpoint;
+        return endpoint;
       }
       // If both are set, concatenate them as url
-      return `${entries.endpoint}/${entries.resource}`;
+      if (endpoint && resource) {
+        const stableEndpoint = decodeURIUntilStable(endpoint);
+        const stableResource = decodeURIUntilStable(resource);
+        return `${stableEndpoint}/${stableResource}`;
+      }
+      return undefined;
     })();
 
     if (!url) throw new Error('No endpoint or resource defined');


### PR DESCRIPTION
When both "endpoint" and "resource" parameters are provided to the standalone viewer, they should still be considered as possibly encoded.

This was made aware in the following issue: https://github.com/Kompakkt/Viewer/issues/51