### PR TITLE
Feat: Menu to reorder/move annotations

### DIFF
--- a/projects/komponents/src/index.ts
+++ b/projects/komponents/src/index.ts
@@ -13,3 +13,5 @@ export * from './textarea/textarea.component';
 export * from './tooltip.directive';
 export * from './wizard-step/wizard-step.component';
 export * from './wizard/wizard.component';
+export * from './menu/menu.component';
+export * from './menu-option/menu-option.component';

--- a/projects/komponents/src/menu-option/menu-option.component.html
+++ b/projects/komponents/src/menu-option/menu-option.component.html
@@ -1,0 +1,1 @@
+<ng-content />

--- a/projects/komponents/src/menu-option/menu-option.component.scss
+++ b/projects/komponents/src/menu-option/menu-option.component.scss
@@ -1,0 +1,19 @@
+:host {
+  display: flex;
+  align-items: center;
+
+  height: 36px;
+  margin-left: -8px;
+  margin-right: -8px;
+  padding: 0px 8px;
+  box-sizing: border-box;
+
+  &:not(.disabled) {
+    &:hover,
+    &:focus,
+    &:focus-within {
+      cursor: pointer;
+      background-color: var(--color-bg-transparent);
+    }
+  }
+}

--- a/projects/komponents/src/menu-option/menu-option.component.ts
+++ b/projects/komponents/src/menu-option/menu-option.component.ts
@@ -1,0 +1,16 @@
+import { Component, HostBinding, input } from '@angular/core';
+
+@Component({
+  selector: 'k-menu-option',
+  standalone: true,
+  imports: [],
+  templateUrl: './menu-option.component.html',
+  styleUrl: './menu-option.component.scss',
+})
+export class MenuOptionComponent {
+  disabled = input<string | undefined>();
+
+  @HostBinding('class.disabled') get disabledClass() {
+    return typeof this.disabled() === 'string';
+  }
+}

--- a/projects/komponents/src/menu/menu.component.html
+++ b/projects/komponents/src/menu/menu.component.html
@@ -1,0 +1,11 @@
+@if (label(); as label) {
+  <k-menu-option disabled>
+    <span
+      ><strong>{{ label }}</strong></span
+    >
+  </k-menu-option>
+}
+
+<div class="k-menu-options">
+  <ng-content />
+</div>

--- a/projects/komponents/src/menu/menu.component.scss
+++ b/projects/komponents/src/menu/menu.component.scss
@@ -1,0 +1,36 @@
+:host {
+  display: flex;
+  cursor: default;
+  pointer-events: none;
+  flex-direction: column;
+  position: absolute;
+  bottom: 50%;
+  right: 50%;
+  transform: translateX(100%) translateY(calc(100% - 16px));
+  background-color: var(--color-gray-dark);
+  margin: 0px;
+  padding: 0px 8px;
+  width: var(--width, 200px);
+  border-radius: 4px;
+  box-shadow: 0px 0px 4px 2px var(--color-bg-solid);
+  z-index: 1;
+  align-items: stretch;
+  filter: opacity(0);
+  transition:
+    transform 200ms ease-out,
+    filter 200ms ease-out;
+  text-align: left;
+  font-size: var(--font-size-small);
+
+  &.show {
+    pointer-events: all;
+    filter: opacity(1);
+    transform: translateX(100%) translateY(100%);
+  }
+}
+
+.k-menu-options {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}

--- a/projects/komponents/src/menu/menu.component.ts
+++ b/projects/komponents/src/menu/menu.component.ts
@@ -1,0 +1,55 @@
+import {
+  Component,
+  ElementRef,
+  HostBinding,
+  inject,
+  input,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+import { fromEvent, Subscription } from 'rxjs';
+import { MenuOptionComponent } from '../menu-option/menu-option.component';
+
+@Component({
+  selector: 'k-menu',
+  standalone: true,
+  imports: [MenuOptionComponent],
+  templateUrl: './menu.component.html',
+  styleUrl: './menu.component.scss',
+})
+export class MenuComponent implements OnInit, OnDestroy {
+  label = input<string>();
+  width = input<string>();
+
+  @HostBinding('style.--width') get widthStyle() {
+    return this.width() ? `${this.width()}px` : undefined;
+  }
+
+  #elementRef = inject<ElementRef<MenuComponent & HTMLElement>>(ElementRef);
+  #subscriptions = new Array<Subscription>();
+
+  ngOnInit() {
+    const parentElement = this.#elementRef.nativeElement.parentElement;
+    if (!parentElement) return;
+
+    parentElement.style.position = 'relative';
+    this.#subscriptions.push(
+      fromEvent(parentElement, 'mouseenter').subscribe(() => {
+        this.#elementRef.nativeElement.classList.add('show');
+      }),
+      fromEvent(parentElement, 'focus').subscribe(() => {
+        this.#elementRef.nativeElement.classList.add('show');
+      }),
+      fromEvent(parentElement, 'mouseleave').subscribe(() => {
+        this.#elementRef.nativeElement.classList.remove('show');
+      }),
+      fromEvent(parentElement, 'blur').subscribe(() => {
+        this.#elementRef.nativeElement.classList.remove('show');
+      }),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.#subscriptions.forEach(subscription => subscription.unsubscribe());
+  }
+}

--- a/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
+++ b/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.html
@@ -1,70 +1,88 @@
 @if (annotation$ | async; as annotation) {
-<img
-  class="preview-image"
-  [src]="annotation.body.content.relatedPerspective.preview | fixImageUrl"
-/>
-<div class="header" (click)="toggleVisibility()">
-  <span class="ranking">{{ annotation.ranking }}</span>
-  <span class="title">{{ annotation.body.content.title || ('No title' | translate) }}</span>
-  <small>{{ (annotation.validated ? 'validated' : 'not validated') | translate }}</small>
-</div>
-<app-markdown-preview
-  id="annotation-content"
-  [data]="annotation.body.content.description || ('No description' | translate)"
-></app-markdown-preview>
-<k-button-row justify="end" gap="4">
-  @if ((canUserEdit$ | async)) {
-  <k-button
-    icon-button
-    color="transparent"
-    [tooltip]="'Edit annotation' | translate"
-    (click)="toggleFullscreen('edit')"
-    ><mat-icon>edit</mat-icon></k-button
-  >
-  }
-  <k-button
-    icon-button
-    color="transparent"
-    [tooltip]="'Copy annotation to collection' | translate"
-    (click)="shareAnnotation()"
-    ><mat-icon>file_copy</mat-icon></k-button
-  >
-  <k-button icon-button color="transparent" [tooltip]="'Export annotation as JSON' | translate"
-    ><mat-icon>file_download</mat-icon></k-button
-  >
-  <k-button
-    icon-button
-    color="transparent"
-    [tooltip]="'Show in fullscreen view' | translate"
-    (click)="toggleFullscreen('preview')"
-    ><mat-icon>select_all</mat-icon></k-button
-  >
-  @if (isAnnotationHidden$ | async) {
-  <k-button
-    icon-button
-    color="transparent"
-    [tooltip]="'Show annotation' | translate"
-    (click)="setVisibility(true)"
-    ><mat-icon>visibility_off</mat-icon></k-button
-  >
-  } @else {
-  <k-button
-    icon-button
-    color="transparent"
-    [tooltip]="'Hide annotation' | translate"
-    (click)="setVisibility(false)"
-    ><mat-icon>visibility</mat-icon></k-button
-  >
-  } @if ((canUserDelete$ | async)) {
-  <k-button
-    icon-button
-    color="transparent"
-    [tooltip]="'Delete annotation' | translate"
-    (click)="deleteAnnotation()"
-    ><mat-icon>delete</mat-icon></k-button
-  >
-  }
-</k-button-row>
+  <img
+    class="preview-image"
+    [src]="annotation.body.content.relatedPerspective.preview | fixImageUrl"
+  />
+  <div class="header" (click)="toggleVisibility()">
+    <span class="ranking">{{ annotation.ranking }}</span>
+    <span class="title">{{ annotation.body.content.title || ('No title' | translate) }}</span>
+    <small>{{ (annotation.validated ? 'validated' : 'not validated') | translate }}</small>
+  </div>
+  <app-markdown-preview
+    id="annotation-content"
+    [data]="annotation.body.content.description || ('No description' | translate)"
+  ></app-markdown-preview>
+  <k-button-row justify="end" gap="4">
+    @if (canUserEdit$ | async) {
+      <k-button
+        icon-button
+        color="transparent"
+        [tooltip]="'Edit annotation' | translate"
+        (click)="toggleFullscreen('edit')"
+        ><mat-icon>edit</mat-icon></k-button
+      >
+    }
+    @if (canUserReorder$ | async) {
+      <k-button icon-button color="transparent" class="reorder-button">
+        <mat-icon>low_priority</mat-icon>
+        <k-menu label="Reorder annotation">
+          <k-menu-option (click)="reorderAnnotation.emit('first')"
+            >Move to first position</k-menu-option
+          >
+          <k-menu-option (click)="reorderAnnotation.emit('last')"
+            >Move to last position</k-menu-option
+          >
+          <k-menu-option (click)="reorderAnnotation.emit('one-up')">One position up</k-menu-option>
+          <k-menu-option (click)="reorderAnnotation.emit('one-down')"
+            >One position down</k-menu-option
+          >
+        </k-menu>
+      </k-button>
+    }
+    <k-button
+      icon-button
+      color="transparent"
+      [tooltip]="'Copy annotation to collection' | translate"
+      (click)="shareAnnotation()"
+      ><mat-icon>file_copy</mat-icon></k-button
+    >
+    <k-button icon-button color="transparent" [tooltip]="'Export annotation as JSON' | translate"
+      ><mat-icon>file_download</mat-icon></k-button
+    >
+    <k-button
+      icon-button
+      color="transparent"
+      [tooltip]="'Show in fullscreen view' | translate"
+      (click)="toggleFullscreen('preview')"
+      ><mat-icon>select_all</mat-icon></k-button
+    >
+    @if (isAnnotationHidden$ | async) {
+      <k-button
+        icon-button
+        color="transparent"
+        [tooltip]="'Show annotation' | translate"
+        (click)="setVisibility(true)"
+        ><mat-icon>visibility_off</mat-icon></k-button
+      >
+    } @else {
+      <k-button
+        icon-button
+        color="transparent"
+        [tooltip]="'Hide annotation' | translate"
+        (click)="setVisibility(false)"
+        ><mat-icon>visibility</mat-icon></k-button
+      >
+    }
+    @if (canUserDelete$ | async) {
+      <k-button
+        icon-button
+        color="transparent"
+        [tooltip]="'Delete annotation' | translate"
+        (click)="deleteAnnotation()"
+        ><mat-icon>delete</mat-icon></k-button
+      >
+    }
+  </k-button-row>
 }
 
 <!-- TODO: Figure out if we need any of the commented out features, e.g. set perspective -->

--- a/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.ts
+++ b/src/app/components/entity-feature-annotations/annotation/annotation-for-editor.component.ts
@@ -15,7 +15,14 @@ import {
   MatCardTitle,
 } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
-import { ButtonComponent, ButtonRowComponent, SlideToggleComponent, TooltipDirective } from 'projects/komponents/src';
+import {
+  ButtonComponent,
+  ButtonRowComponent,
+  SlideToggleComponent,
+  TooltipDirective,
+  MenuComponent,
+  MenuOptionComponent,
+} from 'projects/komponents/src';
 import { FixImageUrlPipe } from 'src/app/pipes/fix-image-url.pipe';
 import { TranslatePipe } from '../../../pipes/translate.pipe';
 import { MarkdownPreviewComponent } from '../../markdown-preview/markdown-preview.component';
@@ -47,6 +54,8 @@ import { AnnotationComponent } from './annotation.component';
     ButtonRowComponent,
     TooltipDirective,
     FixImageUrlPipe,
+    MenuComponent,
+    MenuOptionComponent,
   ],
 })
 export class AnnotationComponentForEditorComponent extends AnnotationComponent {

--- a/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
+++ b/src/app/components/entity-feature-annotations/annotation/annotation.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostBinding, Input, inject } from '@angular/core';
+import { Component, ElementRef, HostBinding, Input, inject, output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Matrix, Vector3 } from '@babylonjs/core';
 import { BehaviorSubject, ReplaySubject, combineLatest, firstValueFrom, interval, map } from 'rxjs';
@@ -29,6 +29,8 @@ import { TranslatePipe } from '../../../pipes/translate.pipe';
 import { DialogAnnotationEditorComponent } from '../../dialogs/dialog-annotation-editor/dialog-annotation-editor.component';
 import { MarkdownPreviewComponent } from '../../markdown-preview/markdown-preview.component';
 
+export type ReorderMovement = 'one-up' | 'one-down' | 'first' | 'last';
+
 @Component({
   selector: 'app-annotation',
   templateUrl: './annotation.component.html',
@@ -58,6 +60,8 @@ export class AnnotationComponent {
   public dialog = inject(MatDialog);
   public userdata = inject(UserdataService);
   public processing = inject(ProcessingService);
+
+  public reorderAnnotation = output<ReorderMovement>();
 
   @Input() entityFileName: string | undefined;
   @Input('annotation') set setAnnotation(annotation: IAnnotation) {
@@ -97,6 +101,7 @@ export class AnnotationComponent {
   public canUserDelete$ = combineLatest([this.isAnnotatingAllowed$, this.isAnnotationOwner$]).pipe(
     map(([isAnnotatingAllowed, isAnnotationOwner]) => isAnnotatingAllowed && isAnnotationOwner),
   );
+  public canUserReorder$ = this.processing.isOwner$.pipe(map(isOwner => isOwner.ofCompilation));
 
   public isSelectedAnnotation$ = combineLatest([
     this.annotation$,

--- a/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.html
+++ b/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.html
@@ -1,78 +1,74 @@
 <h1>{{ 'Annotations' | translate }}</h1>
 
 @if (processing.isInUpload$ | async) {
-<div class="note">
-  <mat-icon>info</mat-icon>
-  <span>{{ 'Info' | translate }}</span>
-  <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
-  <p>{{ 'Please set and save the settings before you add annotations.' | translate }}</p>
-</div>
-} @if (isDefault$ | async) {
-<div class="note">
-  <mat-icon>info</mat-icon>
-  <span>{{ 'Info' | translate }}</span>
-  <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
-  <p>
-    {{
-      'All annotations you create are default annotations and visible for everyone who can access the
+  <div class="note">
+    <mat-icon>info</mat-icon>
+    <span>{{ 'Info' | translate }}</span>
+    <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
+    <p>{{ 'Please set and save the settings before you add annotations.' | translate }}</p>
+  </div>
+}
+@if (isDefault$ | async) {
+  <div class="note">
+    <mat-icon>info</mat-icon>
+    <span>{{ 'Info' | translate }}</span>
+    <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
+    <p>
+      {{
+        'All annotations you create are default annotations and visible for everyone who can access the
       entity.' | translate
-    }}
-  </p>
-</div>
-} @if (isForbidden$ | async) {
-<div class="note">
-  <mat-icon>info</mat-icon>
-  <span>{{ 'Info' | translate }}</span>
-  <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
-  <p>
-    {{
-      'Default Annotations are not editable for foreign entities. Load entity from a collection to save
+      }}
+    </p>
+  </div>
+}
+@if (isForbidden$ | async) {
+  <div class="note">
+    <mat-icon>info</mat-icon>
+    <span>{{ 'Info' | translate }}</span>
+    <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
+    <p>
+      {{
+        'Default Annotations are not editable for foreign entities. Load entity from a collection to save
       your annotations to make them visible for others. If you are the owner of this entity do not load
       it from a collection to edit the default Annotations.' | translate
-    }}
-  </p>
-</div>
-} @if (isAnnotatingAllowed$ | async) {
-<div class="note">
-  <mat-icon>info</mat-icon>
-  <span>{{ 'Info' | translate }}</span>
-  <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
-  <p>{{ 'To add annotations, simply double-click on the entity.' | translate }}</p>
-</div>
+      }}
+    </p>
+  </div>
+}
+@if (isAnnotatingAllowed$ | async) {
+  <div class="note">
+    <mat-icon>info</mat-icon>
+    <span>{{ 'Info' | translate }}</span>
+    <mat-icon class="pointer" (click)="closeNote($event)">close</mat-icon>
+    <p>{{ 'To add annotations, simply double-click on the entity.' | translate }}</p>
+  </div>
 }
 
 <h2>{{ objectName$ | async }}</h2>
 
-<div
-  cdkDropList
-  id="annotations-droplist"
-  class="annotations-list"
-  (cdkDropListDropped)="drop($event)"
->
-  @for (annotation of currentAnnotations$ | async; track annotation) {
-  <app-annotation-for-editor
-    class="annotation-box"
-    [annotation]="annotation"
-    [cdkDragDisabled]="isDraggingDisabled$ | async"
-    cdkDrag
-    cdkDragLockAxis="y"
-  ></app-annotation-for-editor>
+<div class="annotations-list">
+  @for (annotation of currentAnnotations$ | async; track annotation; let index = $index) {
+    <app-annotation-for-editor
+      class="annotation-box"
+      [annotation]="annotation"
+      (reorderAnnotation)="annotations.moveAnnotationByReorderMovement(index, $event)"
+    />
   } @empty {
-  <p style="margin: 0">{{ 'This object has no annotations yet.' | translate }}</p>
+    <p style="margin: 0">{{ 'This object has no annotations yet.' | translate }}</p>
   }
 </div>
 
 @if (annotationCount$ | async; as count) {
-<div id="editor-footermenu">
-  @if (count > 0) {
-  <k-button
-    icon-button
-    color="transparent"
-    tooltip="Export all annotations as JSON"
-    (click)="exportAnnotations()"
-    ><mat-icon>file_download</mat-icon></k-button
-  >
-  }
-  <!--app-broadcast [style.visibility]="isBroadcastingAllowed ? 'visible' : 'hidden'"></app-broadcast-->
-</div>
+  <div id="editor-footermenu">
+    @if (count > 0) {
+      <k-button
+        icon-button
+        color="transparent"
+        tooltip="Export all annotations as JSON"
+        (click)="exportAnnotations()"
+        ><mat-icon>file_download</mat-icon></k-button
+      >
+    }
+    <!--app-broadcast [style.visibility]="isBroadcastingAllowed ? 'visible' : 'hidden'"></app-broadcast-->
+  </div>
 }

--- a/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.scss
+++ b/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.scss
@@ -42,7 +42,7 @@ div.note {
   }
 }
 
-div#annotations-droplist {
+div.annotations-list {
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -56,7 +56,7 @@ div#editor-footermenu {
   bottom: 0;
   display: flex;
   justify-content: center;
-  width: stretch;
+  width: 100%;
   box-sizing: border-box;
   gap: 8px;
   background-color: var(--color-bg-solid);

--- a/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.ts
+++ b/src/app/components/entity-feature-annotations/annotations-editor/annotations-editor.component.ts
@@ -1,7 +1,5 @@
-import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
 import { AsyncPipe } from '@angular/common';
 import { Component, QueryList, ViewChildren, inject } from '@angular/core';
-import { MatCard } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
 import { saveAs } from 'file-saver';
 import { ButtonComponent, TooltipDirective } from 'projects/komponents/src';
@@ -20,10 +18,7 @@ import { AnnotationComponent } from '../annotation/annotation.component';
   styleUrls: ['./annotations-editor.component.scss'],
   standalone: true,
   imports: [
-    MatCard,
-    CdkDropList,
     AnnotationComponentForEditorComponent,
-    CdkDrag,
     MatIcon,
     AsyncPipe,
     TranslatePipe,
@@ -44,51 +39,25 @@ export class AnnotationsEditorComponent {
 
   public currentAnnotations$ = this.annotations.currentAnnotations$;
 
-  get annotationCount$() {
-    return this.currentAnnotations$.pipe(map(arr => arr.length));
-  }
+  annotationCount$ = this.currentAnnotations$.pipe(map(arr => arr.length));
 
-  get objectName$() {
-    return this.processing.entity$.pipe(map(entity => entity?.name));
-  }
+  objectName$ = this.processing.entity$.pipe(map(entity => entity?.name));
 
-  get isDefault$() {
-    return combineLatest([
-      this.processing.hasAnnotationAllowance$,
-      this.processing.compilationLoaded$,
-    ]).pipe(
-      map(
-        ([isAnnotatingAllowed, isCompilationLoaded]) => isAnnotatingAllowed && !isCompilationLoaded,
-      ),
-    );
-  }
+  isDefault$ = combineLatest([
+    this.processing.hasAnnotationAllowance$,
+    this.processing.compilationLoaded$,
+  ]).pipe(
+    map(
+      ([isAnnotatingAllowed, isCompilationLoaded]) => isAnnotatingAllowed && !isCompilationLoaded,
+    ),
+  );
 
-  get isForbidden$() {
-    return combineLatest([
-      this.processing.isInUpload$,
-      this.processing.hasAnnotationAllowance$,
-      this.processing.compilationLoaded$,
-      this.processing.defaultEntityLoaded$,
-    ]).pipe(map(arr => arr.every(boolean => !boolean)));
-  }
-
-  get isDraggingDisabled$() {
-    return combineLatest([
-      this.processing.hasAnnotationAllowance$,
-      this.processing.compilationLoaded$,
-      this.processing.compilation$,
-    ]).pipe(
-      map(([isAnnotatingAllowed, isCompilationLoaded, compilation]) => {
-        if (!isAnnotatingAllowed) return true;
-        if (isCompilationLoaded) return this.userdata.doesUserOwn(compilation);
-        return false;
-      }),
-    );
-  }
-
-  drop(event: CdkDragDrop<string[]>) {
-    this.annotations.moveAnnotationByIndex(event.previousIndex, event.currentIndex);
-  }
+  isForbidden$ = combineLatest([
+    this.processing.isInUpload$,
+    this.processing.hasAnnotationAllowance$,
+    this.processing.compilationLoaded$,
+    this.processing.defaultEntityLoaded$,
+  ]).pipe(map(arr => arr.every(boolean => !boolean)));
 
   exportAnnotations() {
     firstValueFrom(this.currentAnnotations$).then(arr => {

--- a/src/app/services/annotation/annotation.service.ts
+++ b/src/app/services/annotation/annotation.service.ts
@@ -20,6 +20,7 @@ import { MessageService } from '../message/message.service';
 import { ProcessingService } from '../processing/processing.service';
 import { UserdataService } from '../userdata/userdata.service';
 import { createMarker } from './visual3DElements';
+import { ReorderMovement } from 'src/app/components/entity-feature-annotations/annotation/annotation.component';
 
 const isDefaultAnnotation = (annotation: IAnnotation) =>
   !annotation.target.source.relatedCompilation ||
@@ -124,6 +125,19 @@ export class AnnotationService {
     moveItemInArray(arr, from_index + offset, to_index + offset);
     this.annotations$.next(arr);
     await this.changedRankingPositions();
+  }
+
+  public async moveAnnotationByReorderMovement(annotationIndex: number, movement: ReorderMovement) {
+    switch (movement) {
+      case 'first':
+        return this.moveAnnotationByIndex(annotationIndex, 0);
+      case 'last':
+        return this.moveAnnotationByIndex(annotationIndex, this.annotations$.getValue().length - 1);
+      case 'one-up':
+        return this.moveAnnotationByIndex(annotationIndex, annotationIndex - 1);
+      case 'one-down':
+        return this.moveAnnotationByIndex(annotationIndex, annotationIndex + 1);
+    }
   }
 
   public async loadAnnotations() {


### PR DESCRIPTION
Adds a new button on annotation cards, allowing users to move annotations in the list, effectively changing the annotation ranking.

The menu is based on the designs made by @Grizzly127.

This replaces the old drag-n-drop functionality to move annotations, which was not always clean to work with.

![image](https://github.com/user-attachments/assets/e5c9851d-6ffb-444d-b0d7-61ee661cbe2e)
![image](https://github.com/user-attachments/assets/1117faba-dd64-4b86-bff4-055c90818feb)

Note:
This also fixes a bug where compilation ownership was not checked correctly, preventing owners from annotation their own compilations, aswell as preventing them from moving annotations.
